### PR TITLE
Make Abbreviation property nullable in IngredientUnit

### DIFF
--- a/MenuApi/DBModel/IngredientUnit.cs
+++ b/MenuApi/DBModel/IngredientUnit.cs
@@ -5,6 +5,6 @@ namespace MenuApi.DBModel;
 public sealed record IngredientUnit
 {
     public required IngredientUnitName Name { get; init; }
-    public required IngredientUnitAbbreviation Abbreviation { get; init; }
+    public required IngredientUnitAbbreviation? Abbreviation { get; init; }
     public required IngredientUnitType UnitType { get; init; }
 }

--- a/MenuApi/DBModel/IngredientUnit.cs
+++ b/MenuApi/DBModel/IngredientUnit.cs
@@ -5,6 +5,6 @@ namespace MenuApi.DBModel;
 public sealed record IngredientUnit
 {
     public required IngredientUnitName Name { get; init; }
-    public required IngredientUnitAbbreviation? Abbreviation { get; init; }
+    public IngredientUnitAbbreviation? Abbreviation { get; init; }
     public required IngredientUnitType UnitType { get; init; }
 }

--- a/MenuApi/ViewModel/IngredientUnit.cs
+++ b/MenuApi/ViewModel/IngredientUnit.cs
@@ -7,7 +7,7 @@ public class IngredientUnit(IngredientUnitName name, IngredientUnitAbbreviation?
 {
     [Required]
     public IngredientUnitName Name { get; } = name;
-    [Required]
+    
     public IngredientUnitAbbreviation? Abbreviation { get; } = abbreviation;
     [Required]
     public IngredientUnitType Type { get; } = type;

--- a/MenuApi/ViewModel/IngredientUnit.cs
+++ b/MenuApi/ViewModel/IngredientUnit.cs
@@ -3,12 +3,12 @@ using System.ComponentModel.DataAnnotations;
 
 namespace MenuApi.ViewModel;
 
-public class IngredientUnit(IngredientUnitName name, IngredientUnitAbbreviation abbreviation, IngredientUnitType type)
+public class IngredientUnit(IngredientUnitName name, IngredientUnitAbbreviation? abbreviation, IngredientUnitType type)
 {
     [Required]
     public IngredientUnitName Name { get; } = name;
     [Required]
-    public IngredientUnitAbbreviation Abbreviation { get; } = abbreviation;
+    public IngredientUnitAbbreviation? Abbreviation { get; } = abbreviation;
     [Required]
     public IngredientUnitType Type { get; } = type;
 }

--- a/MenuApi/ViewModel/IngredientUnit.cs
+++ b/MenuApi/ViewModel/IngredientUnit.cs
@@ -7,7 +7,7 @@ public class IngredientUnit(IngredientUnitName name, IngredientUnitAbbreviation?
 {
     [Required]
     public IngredientUnitName Name { get; } = name;
-    
+
     public IngredientUnitAbbreviation? Abbreviation { get; } = abbreviation;
     [Required]
     public IngredientUnitType Type { get; } = type;


### PR DESCRIPTION
Updated the `Abbreviation` property in both the `IngredientUnit` record and class to be nullable (`IngredientUnitAbbreviation?`). This change allows the `Abbreviation` to be optional in both the data model and view model contexts.