### PR TITLE
Update test projects with AwesomeAssertions packages

### DIFF
--- a/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
+++ b/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
@@ -20,9 +20,13 @@
 
 	<ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="9.1.0" />		
-		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />		
+		<PackageReference Include="AwesomeAssertions" Version="8.0.2" />		
+		<PackageReference Include="AwesomeAssertions.Analyzers" Version="0.34.2">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />		
-		<PackageReference Include="FluentAssertions" Version="8.2.0" />		
 		<PackageReference Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/MenuApi.Tests/MenuApi.Tests.csproj
+++ b/MenuApi.Tests/MenuApi.Tests.csproj
@@ -19,12 +19,16 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+		<PackageReference Include="AwesomeAssertions" Version="8.0.2" />
+		<PackageReference Include="AwesomeAssertions.Analyzers" Version="0.34.2">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FakeItEasy" Version="8.3.0" />
-		<PackageReference Include="FluentAssertions" Version="8.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
Added `AwesomeAssertions` and `AwesomeAssertions.Analyzers` to `MenuApi.Integration.Tests.csproj` and `MenuApi.Tests.csproj`. Removed `FluentAssertions` from both project files. The `AwesomeAssertions.Analyzers` package includes additional properties for `PrivateAssets` and `IncludeAssets`. The `AutoFixture.Xunit2` package remains unchanged.