### PR TITLE
Switch to use  GitHubActions test logger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,8 @@ jobs:
         run: dotnet dev-certs https --trust
 
       - name: Test with the dotnet CLI
-        run: dotnet test --configuration Release --logger GitHubActions
+        run: >
+          dotnet test
+          --configuration Release
+          --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+          -- RunConfiguration.CollectSourceInformation=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,4 @@ jobs:
         run: dotnet dev-certs https --trust
 
       - name: Test with the dotnet CLI
-        run: dotnet test --logger trx --results-directory TestResults
-
-      - name: Upload dotnet test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: dotnet-test-results
-          path: TestResults
-          # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
+        run: dotnet test --configuration Release --logger GitHubActions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,5 @@ jobs:
         run: >
           dotnet test
           --configuration Release
-          --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+          --logger "GitHubActions;summary.includeSkippedTests=true"
           -- RunConfiguration.CollectSourceInformation=true

--- a/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
+++ b/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
@@ -26,7 +26,11 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />		
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>		
 		<PackageReference Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/MenuApi.Tests/MenuApi.Tests.csproj
+++ b/MenuApi.Tests/MenuApi.Tests.csproj
@@ -29,6 +29,10 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FakeItEasy" Version="8.3.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
This pull request includes changes to the test configuration and dependencies to improve the testing process and integrate with GitHub Actions. The most important changes include updating the test command in the workflow file and adding a new test logger package.

Changes to test configuration:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L45-R45): Modified the test command to run tests with the Release configuration and use the GitHubActions logger. Removed steps for uploading test results.

Dependency updates:

* [`MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj`](diffhunk://#diff-8201b65a8a64e395ca425037359de620ca0b3b82bd602043864d05d4662f1fbdR30-R33): Added `GitHubActionsTestLogger` package to the project with version `2.4.1`.
* [`MenuApi.Tests/MenuApi.Tests.csproj`](diffhunk://#diff-009bf91d7e4b214102a1cdbb087d2bed749ab56874684b6de59465ff362b8a9bR32-R35): Added `GitHubActionsTestLogger` package to the project with version `2.4.1`.