### PR TITLE
Add API request validation (#886)

### DIFF
--- a/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -37,18 +37,24 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
     }
 
     [Theory, ShortStringAutoData]
-    public async Task Create_Recipe(NewRecipe recipe)
+    public async Task Create_Recipe(NewRecipe recipe, string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
         var (_, name) = await PostRecipeAsync(client, recipe);
 
         name.Should().Be(recipe.Name);
     }
 
     [Theory, ShortStringAutoData]
-    public async Task Create_and_Update_Recipe(NewRecipe recipe, NewRecipe updatedRecipe)
+    public async Task Create_and_Update_Recipe(NewRecipe recipe, NewRecipe updatedRecipe, string ingredientName, string ingredientName2)
     {
         using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+        await PostIngredientAsync(client, ingredientName2);
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
+        updatedRecipe.Ingredients = [new RecipeIngredient { Name = ingredientName2, Unit = "Grams", Amount = 200 }];
        
         var (id, _) = await PostRecipeAsync(client, recipe);
 
@@ -58,9 +64,11 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
     }
 
     [Theory, ShortStringAutoData]
-    public async Task Create_And_Get_Recipe(NewRecipe recipe)
+    public async Task Create_And_Get_Recipe(NewRecipe recipe, string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
      
         var (id, _) = await PostRecipeAsync(client, recipe);
         var (getId, name) = await GetRecipeAsync(client, id);
@@ -70,9 +78,11 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
     }
 
     [Theory, ShortStringAutoData]
-    public async Task Create_Recipe_And_Get_Ingredients_Returns_Empty_List(NewRecipe recipe)
+    public async Task Create_Recipe_And_Get_Ingredients(NewRecipe recipe, string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
 
         var (id, _) = await PostRecipeAsync(client, recipe);
 
@@ -82,7 +92,16 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
         var data = await response.Content.ReadAsStringAsync();
         var ingredients = JsonSerializer.Deserialize<List<RecipeIngredient>>(data, jsonOptions);
         ingredients.Should().NotBeNull();
-        ingredients.Should().BeEmpty();
+        ingredients.Should().HaveCount(1);
+        ingredients![0].Name.Should().Be(ingredientName);
+    }
+
+    private static async Task PostIngredientAsync(HttpClient client, string name)
+    {
+        var body = new { name, unitIds = new[] { 4 } }; // Grams
+        var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/ingredient", content);
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
     }
 
     private static async Task<(int Id, string Name)> PostRecipeAsync(HttpClient client, NewRecipe recipe)

--- a/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -101,14 +101,14 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
     private static async Task PostIngredientAsync(HttpClient client, string name)
     {
         var body = new { name, unitIds = new[] { 4 } }; // Grams
-        var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+        using var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
         using var response = await client.PostAsync("/api/ingredient", content);
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
     }
 
     private static async Task<(int Id, string Name)> PostRecipeAsync(HttpClient client, NewRecipe recipe)
     {
-        var requestContent = new StringContent(JsonSerializer.Serialize(recipe), Encoding.UTF8, "application/json");
+        using var requestContent = new StringContent(JsonSerializer.Serialize(recipe), Encoding.UTF8, "application/json");
         using var response = await client.PostAsync("/api/recipe", requestContent);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
@@ -121,7 +121,7 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
 
     private static async Task<(int Id, string Name)> PutRecipeAsync(HttpClient client, int id, NewRecipe recipe)
     {
-        var requestContent = new StringContent(JsonSerializer.Serialize(recipe), Encoding.UTF8, "application/json");
+        using var requestContent = new StringContent(JsonSerializer.Serialize(recipe), Encoding.UTF8, "application/json");
         using var response = await client.PutAsync($"/api/recipe/{id}", requestContent);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
@@ -180,3 +180,4 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
         public decimal Amount { get; set; }
     }
 }
+

--- a/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -10,6 +10,8 @@ namespace MenuApi.Integration.Tests;
 [Collection("API Host Collection")]
 public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
 {
+    private const string Grams = "Grams";
+
     readonly JsonSerializerOptions jsonOptions;
     private readonly ApiTestFixture fixture;
 
@@ -41,7 +43,7 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         await PostIngredientAsync(client, ingredientName);
-        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }];
         var (_, name) = await PostRecipeAsync(client, recipe);
 
         name.Should().Be(recipe.Name);
@@ -53,8 +55,8 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
         using var client = await fixture.GetHttpClient();
         await PostIngredientAsync(client, ingredientName);
         await PostIngredientAsync(client, ingredientName2);
-        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
-        updatedRecipe.Ingredients = [new RecipeIngredient { Name = ingredientName2, Unit = "Grams", Amount = 200 }];
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }];
+        updatedRecipe.Ingredients = [new RecipeIngredient { Name = ingredientName2, Unit = Grams, Amount = 200 }];
        
         var (id, _) = await PostRecipeAsync(client, recipe);
 
@@ -68,7 +70,7 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         await PostIngredientAsync(client, ingredientName);
-        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }];
      
         var (id, _) = await PostRecipeAsync(client, recipe);
         var (getId, name) = await GetRecipeAsync(client, id);
@@ -82,7 +84,7 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         await PostIngredientAsync(client, ingredientName);
-        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }];
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }];
 
         var (id, _) = await PostRecipeAsync(client, recipe);
 

--- a/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
+++ b/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
@@ -27,7 +27,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     public async Task CreateRecipe_MissingProperties_Returns400()
     {
         using var client = await fixture.GetHttpClient();
-        var content = new StringContent("{}", Encoding.UTF8, ApplicationJson);
+        using var content = new StringContent("{}", Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync(ApiRecipeRoute, content);
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
     }
@@ -37,7 +37,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         var body = new NewRecipe { Name = "", Ingredients = [] };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync(ApiRecipeRoute, content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
@@ -60,7 +60,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
             Name = "Test Recipe",
             Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = Grams, Amount = 100 }]
         };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync(ApiRecipeRoute, content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
@@ -88,7 +88,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         var body = new NewIngredient { Name = "", UnitIds = [1] };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync("/api/ingredient", content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
@@ -99,7 +99,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         var body = new NewIngredient { Name = "SomeIngredient", UnitIds = [] };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync("/api/ingredient", content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
@@ -112,7 +112,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
         var recipeId = await CreateRecipeAsync(client, recipeName, ingredientName);
 
         var updateBody = new NewRecipe { Name = "", Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
-        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
 
         await updateResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
@@ -129,7 +129,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
             Name = recipeName,
             Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = Grams, Amount = 100 }]
         };
-        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
 
         await updateResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
@@ -140,7 +140,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
         await PostIngredientAsync(client, ingredientName);
 
         var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
-        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var createResponse = await client.PostAsync(ApiRecipeRoute, createContent);
         await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
@@ -152,7 +152,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     private async Task PostIngredientAsync(HttpClient client, string name)
     {
         var body = new NewIngredient { Name = name, UnitIds = [4] }; // Grams
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync("/api/ingredient", content);
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
     }
@@ -176,3 +176,4 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
         public List<int> UnitIds { get; set; } = [];
     }
 }
+

--- a/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
+++ b/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
@@ -10,6 +10,10 @@ namespace MenuApi.Integration.Tests;
 [Collection("API Host Collection")]
 public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
 {
+    private const string ApplicationJson = "application/json";
+    private const string ApiRecipeRoute = "/api/recipe";
+    private const string Grams = "Grams";
+
     private readonly JsonSerializerOptions jsonOptions;
     private readonly ApiTestFixture fixture;
 
@@ -23,8 +27,8 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     public async Task CreateRecipe_MissingProperties_Returns400()
     {
         using var client = await fixture.GetHttpClient();
-        var content = new StringContent("{}", Encoding.UTF8, "application/json");
-        using var response = await client.PostAsync("/api/recipe", content);
+        var content = new StringContent("{}", Encoding.UTF8, ApplicationJson);
+        using var response = await client.PostAsync(ApiRecipeRoute, content);
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
     }
 
@@ -33,8 +37,8 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         var body = new NewRecipe { Name = "", Ingredients = [] };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
-        using var response = await client.PostAsync("/api/recipe", content);
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var response = await client.PostAsync(ApiRecipeRoute, content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
 
@@ -44,7 +48,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
 
         root.GetProperty("status").GetInt32().Should().Be(400);
         root.GetProperty("title").GetString().Should().Be("One or more validation errors occurred.");
-        root.TryGetProperty("errors", out var errors).Should().BeTrue();
+        root.TryGetProperty("errors", out _).Should().BeTrue();
     }
 
     [Fact]
@@ -54,10 +58,10 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
         var body = new NewRecipe
         {
             Name = "Test Recipe",
-            Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = "Grams", Amount = 100 }]
+            Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = Grams, Amount = 100 }]
         };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
-        using var response = await client.PostAsync("/api/recipe", content);
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var response = await client.PostAsync(ApiRecipeRoute, content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
 
@@ -84,7 +88,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         var body = new NewIngredient { Name = "", UnitIds = [1] };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync("/api/ingredient", content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
@@ -95,7 +99,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     {
         using var client = await fixture.GetHttpClient();
         var body = new NewIngredient { Name = "SomeIngredient", UnitIds = [] };
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync("/api/ingredient", content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
@@ -108,17 +112,17 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
 
         await PostIngredientAsync(client, ingredientName);
 
-        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }] };
-        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, "application/json");
-        using var createResponse = await client.PostAsync("/api/recipe", createContent);
+        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
+        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var createResponse = await client.PostAsync(ApiRecipeRoute, createContent);
         await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         using var createStream = await createResponse.Content.ReadAsStreamAsync();
         using var createDoc = await JsonDocument.ParseAsync(createStream);
         var recipeId = createDoc.RootElement.GetProperty("id").GetInt32();
 
-        var updateBody = new NewRecipe { Name = "", Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }] };
-        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        var updateBody = new NewRecipe { Name = "", Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
+        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
 
         await updateResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
@@ -131,9 +135,9 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
 
         await PostIngredientAsync(client, ingredientName);
 
-        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }] };
-        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, "application/json");
-        using var createResponse = await client.PostAsync("/api/recipe", createContent);
+        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
+        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var createResponse = await client.PostAsync(ApiRecipeRoute, createContent);
         await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         using var createStream = await createResponse.Content.ReadAsStreamAsync();
@@ -143,9 +147,9 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
         var updateBody = new NewRecipe
         {
             Name = recipeName,
-            Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = "Grams", Amount = 100 }]
+            Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = Grams, Amount = 100 }]
         };
-        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
 
         await updateResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
@@ -154,7 +158,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     private async Task PostIngredientAsync(HttpClient client, string name)
     {
         var body = new NewIngredient { Name = name, UnitIds = [4] }; // Grams
-        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, ApplicationJson);
         using var response = await client.PostAsync("/api/ingredient", content);
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
     }

--- a/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
+++ b/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
@@ -109,17 +109,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     public async Task UpdateRecipe_EmptyName_Returns400(string recipeName, string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
-
-        await PostIngredientAsync(client, ingredientName);
-
-        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
-        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, ApplicationJson);
-        using var createResponse = await client.PostAsync(ApiRecipeRoute, createContent);
-        await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        using var createStream = await createResponse.Content.ReadAsStreamAsync();
-        using var createDoc = await JsonDocument.ParseAsync(createStream);
-        var recipeId = createDoc.RootElement.GetProperty("id").GetInt32();
+        var recipeId = await CreateRecipeAsync(client, recipeName, ingredientName);
 
         var updateBody = new NewRecipe { Name = "", Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
         var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, ApplicationJson);
@@ -132,17 +122,7 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
     public async Task UpdateRecipe_NonExistentIngredient_Returns422(string recipeName, string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
-
-        await PostIngredientAsync(client, ingredientName);
-
-        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
-        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, ApplicationJson);
-        using var createResponse = await client.PostAsync(ApiRecipeRoute, createContent);
-        await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        using var createStream = await createResponse.Content.ReadAsStreamAsync();
-        using var createDoc = await JsonDocument.ParseAsync(createStream);
-        var recipeId = createDoc.RootElement.GetProperty("id").GetInt32();
+        var recipeId = await CreateRecipeAsync(client, recipeName, ingredientName);
 
         var updateBody = new NewRecipe
         {
@@ -153,6 +133,20 @@ public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
         using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
 
         await updateResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+    }
+
+    private async Task<int> CreateRecipeAsync(HttpClient client, string recipeName, string ingredientName)
+    {
+        await PostIngredientAsync(client, ingredientName);
+
+        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }] };
+        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, ApplicationJson);
+        using var createResponse = await client.PostAsync(ApiRecipeRoute, createContent);
+        await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var createStream = await createResponse.Content.ReadAsStreamAsync();
+        using var createDoc = await JsonDocument.ParseAsync(createStream);
+        return createDoc.RootElement.GetProperty("id").GetInt32();
     }
 
     private async Task PostIngredientAsync(HttpClient client, string name)

--- a/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
+++ b/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
@@ -1,0 +1,180 @@
+using AwesomeAssertions;
+using MenuApi.Integration.Tests.Factory;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace MenuApi.Integration.Tests;
+
+[Collection("API Host Collection")]
+public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
+{
+    private readonly JsonSerializerOptions jsonOptions;
+    private readonly ApiTestFixture fixture;
+
+    public ValidationIntegrationTests(ApiTestFixture fixture)
+    {
+        jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CreateRecipe_MissingProperties_Returns400()
+    {
+        using var client = await fixture.GetHttpClient();
+        var content = new StringContent("{}", Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+        await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateRecipe_EmptyName_Returns400WithProblemDetails()
+    {
+        using var client = await fixture.GetHttpClient();
+        var body = new NewRecipe { Name = "", Ingredients = [] };
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(responseBody);
+        var root = doc.RootElement;
+
+        root.GetProperty("status").GetInt32().Should().Be(400);
+        root.GetProperty("title").GetString().Should().Be("One or more validation errors occurred.");
+        root.TryGetProperty("errors", out var errors).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateRecipe_NonExistentIngredient_Returns422()
+    {
+        using var client = await fixture.GetHttpClient();
+        var body = new NewRecipe
+        {
+            Name = "Test Recipe",
+            Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = "Grams", Amount = 100 }]
+        };
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(responseBody);
+        doc.RootElement.GetProperty("status").GetInt32().Should().Be(422);
+    }
+
+    [Fact]
+    public async Task GetRecipe_NonExistentId_Returns404()
+    {
+        using var client = await fixture.GetHttpClient();
+        using var response = await client.GetAsync("/api/recipe/99999");
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(responseBody);
+        doc.RootElement.GetProperty("status").GetInt32().Should().Be(404);
+    }
+
+    [Fact]
+    public async Task CreateIngredient_EmptyName_Returns400()
+    {
+        using var client = await fixture.GetHttpClient();
+        var body = new NewIngredient { Name = "", UnitIds = [1] };
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/ingredient", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateIngredient_EmptyUnitIds_Returns400()
+    {
+        using var client = await fixture.GetHttpClient();
+        var body = new NewIngredient { Name = "SomeIngredient", UnitIds = [] };
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/ingredient", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+    }
+
+    [Theory, ShortStringAutoData]
+    public async Task UpdateRecipe_EmptyName_Returns400(string recipeName, string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName);
+
+        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }] };
+        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var createResponse = await client.PostAsync("/api/recipe", createContent);
+        await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var createStream = await createResponse.Content.ReadAsStreamAsync();
+        using var createDoc = await JsonDocument.ParseAsync(createStream);
+        var recipeId = createDoc.RootElement.GetProperty("id").GetInt32();
+
+        var updateBody = new NewRecipe { Name = "", Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }] };
+        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
+
+        await updateResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+    }
+
+    [Theory, ShortStringAutoData]
+    public async Task UpdateRecipe_NonExistentIngredient_Returns422(string recipeName, string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName);
+
+        var createBody = new NewRecipe { Name = recipeName, Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100 }] };
+        var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var createResponse = await client.PostAsync("/api/recipe", createContent);
+        await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var createStream = await createResponse.Content.ReadAsStreamAsync();
+        using var createDoc = await JsonDocument.ParseAsync(createStream);
+        var recipeId = createDoc.RootElement.GetProperty("id").GetInt32();
+
+        var updateBody = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [new RecipeIngredient { Name = "NonExistentIngredient", Unit = "Grams", Amount = 100 }]
+        };
+        var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
+
+        await updateResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+    }
+
+    private async Task PostIngredientAsync(HttpClient client, string name)
+    {
+        var body = new NewIngredient { Name = name, UnitIds = [4] }; // Grams
+        var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/ingredient", content);
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+    }
+
+    public class NewRecipe
+    {
+        public List<RecipeIngredient> Ingredients { get; set; } = [];
+        public string Name { get; set; }
+    }
+
+    public class RecipeIngredient
+    {
+        public string Name { get; set; }
+        public string Unit { get; set; }
+        public decimal Amount { get; set; }
+    }
+
+    public class NewIngredient
+    {
+        public string Name { get; set; }
+        public List<int> UnitIds { get; set; } = [];
+    }
+}

--- a/MenuApi.Tests/Controllers/RecipeApiTests.cs
+++ b/MenuApi.Tests/Controllers/RecipeApiTests.cs
@@ -1,10 +1,15 @@
-﻿using AwesomeAssertions;
+﻿#nullable enable
+
+using AwesomeAssertions;
 using FakeItEasy;
 using MenuApi.Recipes;
 using MenuApi.Services;
 using MenuApi.ValueObjects;
 using MenuApi.ViewModel;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Xunit;
+
+#nullable enable
 
 namespace MenuApi.Tests.Controllers;
 
@@ -34,7 +39,19 @@ public class RecipeApiTests
 
         var result = await RecipeApi.GetRecipeAsync(recipeService, recipeId);
 
-        result.Should().Be(recipe);
+        var okResult = result.Should().BeOfType<Ok<FullRecipe>>().Subject;
+        okResult.Value.Should().Be(recipe);
+    }
+
+    [Theory, CustomAutoData]
+    public async Task GetRecipeAsync_NotFound_Returns404(RecipeId recipeId)
+    {
+        A.CallTo(() => recipeService.GetRecipeAsync(recipeId)).Returns((FullRecipe?)null);
+
+        var result = await RecipeApi.GetRecipeAsync(recipeService, recipeId);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(404);
     }
 
     [Theory, CustomAutoData]

--- a/MenuApi.Tests/Controllers/RecipeApiTests.cs
+++ b/MenuApi.Tests/Controllers/RecipeApiTests.cs
@@ -9,8 +9,6 @@ using MenuApi.ViewModel;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Xunit;
 
-#nullable enable
-
 namespace MenuApi.Tests.Controllers;
 
 public class RecipeApiTests

--- a/MenuApi.Tests/Controllers/RecipeApiTests.cs
+++ b/MenuApi.Tests/Controllers/RecipeApiTests.cs
@@ -44,7 +44,8 @@ public class RecipeApiTests
     [Theory, CustomAutoData]
     public async Task GetRecipeAsync_NotFound_Returns404(RecipeId recipeId)
     {
-        A.CallTo(() => recipeService.GetRecipeAsync(recipeId)).Returns((FullRecipe?)null);
+        FullRecipe? recipe = null;
+        A.CallTo(() => recipeService.GetRecipeAsync(recipeId)).Returns(recipe);
 
         var result = await RecipeApi.GetRecipeAsync(recipeService, recipeId);
 
@@ -85,3 +86,4 @@ public class RecipeApiTests
         result.Should().Be(recipe);
     }
 }
+

--- a/MenuApi.Tests/MenuApi.Tests.csproj
+++ b/MenuApi.Tests/MenuApi.Tests.csproj
@@ -19,7 +19,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
+		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />
 		<PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8">
 		  <PrivateAssets>all</PrivateAssets>

--- a/MenuApi.Tests/Validation/NewIngredientValidatorTests.cs
+++ b/MenuApi.Tests/Validation/NewIngredientValidatorTests.cs
@@ -35,7 +35,7 @@ public class NewIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+        result.ShouldHaveValidationErrorFor("Name");
     }
 
     [Fact]
@@ -79,6 +79,6 @@ public class NewIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+        result.ShouldHaveValidationErrorFor("Name");
     }
 }

--- a/MenuApi.Tests/Validation/NewIngredientValidatorTests.cs
+++ b/MenuApi.Tests/Validation/NewIngredientValidatorTests.cs
@@ -25,6 +25,22 @@ public class NewIngredientValidatorTests
     }
 
     [Fact]
+    public void UninitializedName_Fails()
+    {
+#pragma warning disable VOG009
+        var ingredient = new NewIngredient
+        {
+            Name = default,
+            UnitIds = [1, 2]
+        };
+#pragma warning restore VOG009
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor("Name");
+    }
+
+    [Fact]
     public void NameTooLong_Fails()
     {
         var ingredient = new NewIngredient

--- a/MenuApi.Tests/Validation/NewIngredientValidatorTests.cs
+++ b/MenuApi.Tests/Validation/NewIngredientValidatorTests.cs
@@ -1,0 +1,84 @@
+using FluentValidation.TestHelper;
+using MenuApi.Validation;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Xunit;
+
+namespace MenuApi.Tests.Validation;
+
+public class NewIngredientValidatorTests
+{
+    private readonly NewIngredientValidator validator = new();
+
+    [Fact]
+    public void ValidIngredient_Passes()
+    {
+        var ingredient = new NewIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            UnitIds = [1, 2]
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void NameTooLong_Fails()
+    {
+        var ingredient = new NewIngredient
+        {
+            Name = IngredientName.From(new string('a', 51)),
+            UnitIds = [1]
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+    }
+
+    [Fact]
+    public void EmptyUnitIds_Fails()
+    {
+        var ingredient = new NewIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            UnitIds = []
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.UnitIds);
+    }
+
+    [Fact]
+    public void ZeroUnitId_Fails()
+    {
+        var ingredient = new NewIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            UnitIds = [0]
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor("UnitIds[0]");
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("  \t  ")]
+    public void WhitespaceName_Fails(string name)
+    {
+        var ingredient = new NewIngredient
+        {
+            Name = IngredientName.From(name),
+            UnitIds = [1]
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+    }
+}

--- a/MenuApi.Tests/Validation/NewRecipeValidatorTests.cs
+++ b/MenuApi.Tests/Validation/NewRecipeValidatorTests.cs
@@ -59,6 +59,22 @@ public class NewRecipeValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.Ingredients);
     }
 
+    [Fact]
+    public void UninitializedName_Fails()
+    {
+#pragma warning disable VOG009
+        var recipe = new NewRecipe
+        {
+            Name = default,
+            Ingredients = [CreateValidIngredient()]
+        };
+#pragma warning restore VOG009
+
+        var result = validator.TestValidate(recipe);
+
+        result.ShouldHaveValidationErrorFor("Name");
+    }
+
     [Theory]
     [InlineData(" ")]
     [InlineData("  \t  ")]

--- a/MenuApi.Tests/Validation/NewRecipeValidatorTests.cs
+++ b/MenuApi.Tests/Validation/NewRecipeValidatorTests.cs
@@ -42,7 +42,7 @@ public class NewRecipeValidatorTests
 
         var result = validator.TestValidate(recipe);
 
-        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+        result.ShouldHaveValidationErrorFor("Name");
     }
 
     [Fact]
@@ -72,6 +72,6 @@ public class NewRecipeValidatorTests
 
         var result = validator.TestValidate(recipe);
 
-        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+        result.ShouldHaveValidationErrorFor("Name");
     }
 }

--- a/MenuApi.Tests/Validation/NewRecipeValidatorTests.cs
+++ b/MenuApi.Tests/Validation/NewRecipeValidatorTests.cs
@@ -1,0 +1,77 @@
+using FluentValidation.TestHelper;
+using MenuApi.Validation;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Xunit;
+
+namespace MenuApi.Tests.Validation;
+
+public class NewRecipeValidatorTests
+{
+    private readonly NewRecipeValidator validator = new();
+
+    private static RecipeIngredient CreateValidIngredient() => new()
+    {
+        Name = IngredientName.From("Flour"),
+        Unit = IngredientUnitName.From("Grams"),
+        Amount = IngredientAmount.From(100m)
+    };
+
+    [Fact]
+    public void ValidRecipe_Passes()
+    {
+        var recipe = new NewRecipe
+        {
+            Name = RecipeName.From("Test Recipe"),
+            Ingredients = [CreateValidIngredient()]
+        };
+
+        var result = validator.TestValidate(recipe);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void NameTooLong_Fails()
+    {
+        var recipe = new NewRecipe
+        {
+            Name = RecipeName.From(new string('a', 501)),
+            Ingredients = [CreateValidIngredient()]
+        };
+
+        var result = validator.TestValidate(recipe);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+    }
+
+    [Fact]
+    public void EmptyIngredients_Fails()
+    {
+        var recipe = new NewRecipe
+        {
+            Name = RecipeName.From("Valid Recipe"),
+            Ingredients = []
+        };
+
+        var result = validator.TestValidate(recipe);
+
+        result.ShouldHaveValidationErrorFor(x => x.Ingredients);
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("  \t  ")]
+    public void WhitespaceName_Fails(string name)
+    {
+        var recipe = new NewRecipe
+        {
+            Name = RecipeName.From(name),
+            Ingredients = [CreateValidIngredient()]
+        };
+
+        var result = validator.TestValidate(recipe);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+    }
+}

--- a/MenuApi.Tests/Validation/RecipeIngredientValidatorTests.cs
+++ b/MenuApi.Tests/Validation/RecipeIngredientValidatorTests.cs
@@ -27,6 +27,57 @@ public class RecipeIngredientValidatorTests
     }
 
     [Fact]
+    public void UninitializedName_Fails()
+    {
+#pragma warning disable VOG009
+        var ingredient = new RecipeIngredient
+        {
+            Name = default,
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m)
+        };
+#pragma warning restore VOG009
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor("Name");
+    }
+
+    [Fact]
+    public void UninitializedUnit_Fails()
+    {
+#pragma warning disable VOG009
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            Unit = default,
+            Amount = IngredientAmount.From(100m)
+        };
+#pragma warning restore VOG009
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor("Unit");
+    }
+
+    [Fact]
+    public void UninitializedAmount_Fails()
+    {
+#pragma warning disable VOG009
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = default
+        };
+#pragma warning restore VOG009
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor("Amount");
+    }
+
+    [Fact]
     public void NameTooLong_Fails()
     {
         var ingredient = new RecipeIngredient

--- a/MenuApi.Tests/Validation/RecipeIngredientValidatorTests.cs
+++ b/MenuApi.Tests/Validation/RecipeIngredientValidatorTests.cs
@@ -1,0 +1,122 @@
+using AwesomeAssertions;
+using FluentValidation.TestHelper;
+using MenuApi.Validation;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Xunit;
+
+namespace MenuApi.Tests.Validation;
+
+public class RecipeIngredientValidatorTests
+{
+    private readonly RecipeIngredientValidator validator = new();
+
+    [Fact]
+    public void ValidIngredient_Passes()
+    {
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m)
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void NameTooLong_Fails()
+    {
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From(new string('a', 51)),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m)
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ZeroOrNegativeAmount_Fails(int amount)
+    {
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(amount)
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Amount.Value);
+    }
+
+    [Fact]
+    public void TooManyDecimalPlaces_Fails()
+    {
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(1.12345m)
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Amount.Value);
+    }
+
+    [Fact]
+    public void TooManyTotalDigits_Fails()
+    {
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(1234567m)
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Amount.Value);
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("  \t  ")]
+    public void WhitespaceName_Fails(string name)
+    {
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From(name),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m)
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+    }
+
+    [Fact]
+    public void UnitTooLong_Fails()
+    {
+        var ingredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Flour"),
+            Unit = IngredientUnitName.From(new string('a', 51)),
+            Amount = IngredientAmount.From(100m)
+        };
+
+        var result = validator.TestValidate(ingredient);
+
+        result.ShouldHaveValidationErrorFor(x => x.Unit.Value);
+    }
+}

--- a/MenuApi.Tests/Validation/RecipeIngredientValidatorTests.cs
+++ b/MenuApi.Tests/Validation/RecipeIngredientValidatorTests.cs
@@ -38,7 +38,7 @@ public class RecipeIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+        result.ShouldHaveValidationErrorFor("Name");
     }
 
     [Theory]
@@ -55,7 +55,7 @@ public class RecipeIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Amount.Value);
+        result.ShouldHaveValidationErrorFor("Amount");
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class RecipeIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Amount.Value);
+        result.ShouldHaveValidationErrorFor("Amount");
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class RecipeIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Amount.Value);
+        result.ShouldHaveValidationErrorFor("Amount");
     }
 
     [Theory]
@@ -102,7 +102,7 @@ public class RecipeIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Name.Value);
+        result.ShouldHaveValidationErrorFor("Name");
     }
 
     [Fact]
@@ -117,6 +117,6 @@ public class RecipeIngredientValidatorTests
 
         var result = validator.TestValidate(ingredient);
 
-        result.ShouldHaveValidationErrorFor(x => x.Unit.Value);
+        result.ShouldHaveValidationErrorFor("Unit");
     }
 }

--- a/MenuApi.Tests/Validation/ValidationFilterTests.cs
+++ b/MenuApi.Tests/Validation/ValidationFilterTests.cs
@@ -9,6 +9,7 @@ using MenuApi.ViewModel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.DependencyInjection;
+using Vogen;
 using Xunit;
 
 namespace MenuApi.Tests.Validation;
@@ -105,6 +106,36 @@ public class ValidationFilterTests
     public async Task UninitializedVogenStruct_Returns400()
     {
         // Simulates when FluentValidation throws accessing uninitialized Vogen structs
+        var httpContext = new DefaultHttpContext();
+        var services = new ServiceCollection();
+        var throwingValidator = A.Fake<IValidator<NewRecipe>>();
+        A.CallTo(() => throwingValidator.ValidateAsync(A<NewRecipe>._, A<CancellationToken>._))
+            .ThrowsAsync(new ValueObjectValidationException("Use of uninitialized Value Object."));
+        services.AddScoped<IValidator<NewRecipe>>(_ => throwingValidator);
+        httpContext.RequestServices = services.BuildServiceProvider();
+
+        var recipe = new NewRecipe
+        {
+            Name = RecipeName.From("test"),
+            Ingredients = []
+        };
+        var context = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => context.HttpContext).Returns(httpContext);
+        A.CallTo(() => context.Arguments).Returns(new List<object?> { recipe });
+
+        EndpointFilterDelegate next = _ => ValueTask.FromResult<object?>(null);
+        var filter = new ValidationFilter<NewRecipe>();
+
+        var result = await filter.InvokeAsync(context, next);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task UninitializedVogenStruct_MessageFallback_Returns400()
+    {
+        // Verifies fallback path: non-Vogen exception with the Vogen message still returns 400
         var httpContext = new DefaultHttpContext();
         var services = new ServiceCollection();
         var throwingValidator = A.Fake<IValidator<NewRecipe>>();

--- a/MenuApi.Tests/Validation/ValidationFilterTests.cs
+++ b/MenuApi.Tests/Validation/ValidationFilterTests.cs
@@ -163,6 +163,23 @@ public class ValidationFilterTests
     }
 
     [Fact]
+    public async Task MissingValidator_ThrowsInvalidOperationException()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.RequestServices = new ServiceCollection().BuildServiceProvider();
+
+        var context = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => context.HttpContext).Returns(httpContext);
+
+        EndpointFilterDelegate next = _ => ValueTask.FromResult<object?>(null);
+        var filter = new ValidationFilter<NewRecipe>();
+
+        Func<Task> act = async () => await filter.InvokeAsync(context, next);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
     public async Task NonVogenException_Propagates()
     {
         var httpContext = new DefaultHttpContext();

--- a/MenuApi.Tests/Validation/ValidationFilterTests.cs
+++ b/MenuApi.Tests/Validation/ValidationFilterTests.cs
@@ -1,0 +1,162 @@
+#nullable enable
+#nullable enable
+
+using AwesomeAssertions;
+using FakeItEasy;
+using FluentValidation;
+using MenuApi.Validation;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MenuApi.Tests.Validation;
+
+public class ValidationFilterTests
+{
+    private static DefaultHttpContext CreateHttpContextWithValidator()
+    {
+        var httpContext = new DefaultHttpContext();
+        var services = new ServiceCollection();
+        services.AddScoped<IValidator<NewRecipe>, NewRecipeValidator>();
+        httpContext.RequestServices = services.BuildServiceProvider();
+        return httpContext;
+    }
+
+    [Fact]
+    public async Task InvalidRequest_Returns400()
+    {
+        var invalidRecipe = new NewRecipe
+        {
+            Name = RecipeName.From(new string('a', 501)),
+            Ingredients = []
+        };
+
+        var httpContext = CreateHttpContextWithValidator();
+        var context = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => context.HttpContext).Returns(httpContext);
+        A.CallTo(() => context.Arguments).Returns(new List<object?> { invalidRecipe });
+
+        EndpointFilterDelegate next = _ => ValueTask.FromResult<object?>(null);
+        var filter = new ValidationFilter<NewRecipe>();
+
+        var result = await filter.InvokeAsync(context, next);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task ValidRequest_CallsNext()
+    {
+        var validRecipe = new NewRecipe
+        {
+            Name = RecipeName.From("Valid Recipe"),
+            Ingredients =
+            [
+                new RecipeIngredient
+                {
+                    Name = IngredientName.From("Flour"),
+                    Unit = IngredientUnitName.From("Grams"),
+                    Amount = IngredientAmount.From(100m)
+                }
+            ]
+        };
+
+        var httpContext = CreateHttpContextWithValidator();
+        var context = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => context.HttpContext).Returns(httpContext);
+        A.CallTo(() => context.Arguments).Returns(new List<object?> { validRecipe });
+
+        var nextCalled = false;
+        var expectedResult = new object();
+        EndpointFilterDelegate next = _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(expectedResult);
+        };
+
+        var filter = new ValidationFilter<NewRecipe>();
+        var result = await filter.InvokeAsync(context, next);
+
+        nextCalled.Should().BeTrue();
+        result.Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public async Task NullBody_Returns400()
+    {
+        var httpContext = CreateHttpContextWithValidator();
+        var context = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => context.HttpContext).Returns(httpContext);
+        A.CallTo(() => context.Arguments).Returns(new List<object?> { });
+
+        EndpointFilterDelegate next = _ => ValueTask.FromResult<object?>(null);
+        var filter = new ValidationFilter<NewRecipe>();
+
+        var result = await filter.InvokeAsync(context, next);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task UninitializedVogenStruct_Returns400()
+    {
+        // Simulates when FluentValidation throws accessing uninitialized Vogen structs
+        var httpContext = new DefaultHttpContext();
+        var services = new ServiceCollection();
+        var throwingValidator = A.Fake<IValidator<NewRecipe>>();
+        A.CallTo(() => throwingValidator.ValidateAsync(A<NewRecipe>._, A<CancellationToken>._))
+            .ThrowsAsync(new Exception("Use of uninitialized Value Object."));
+        services.AddScoped<IValidator<NewRecipe>>(_ => throwingValidator);
+        httpContext.RequestServices = services.BuildServiceProvider();
+
+        var recipe = new NewRecipe
+        {
+            Name = RecipeName.From("test"),
+            Ingredients = []
+        };
+        var context = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => context.HttpContext).Returns(httpContext);
+        A.CallTo(() => context.Arguments).Returns(new List<object?> { recipe });
+
+        EndpointFilterDelegate next = _ => ValueTask.FromResult<object?>(null);
+        var filter = new ValidationFilter<NewRecipe>();
+
+        var result = await filter.InvokeAsync(context, next);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task NonVogenException_Propagates()
+    {
+        var httpContext = new DefaultHttpContext();
+        var services = new ServiceCollection();
+        var throwingValidator = A.Fake<IValidator<NewRecipe>>();
+        A.CallTo(() => throwingValidator.ValidateAsync(A<NewRecipe>._, A<CancellationToken>._))
+            .ThrowsAsync(new InvalidOperationException("Some unrelated error"));
+        services.AddScoped<IValidator<NewRecipe>>(_ => throwingValidator);
+        httpContext.RequestServices = services.BuildServiceProvider();
+
+        var recipe = new NewRecipe
+        {
+            Name = RecipeName.From("test"),
+            Ingredients = []
+        };
+        var context = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => context.HttpContext).Returns(httpContext);
+        A.CallTo(() => context.Arguments).Returns(new List<object?> { recipe });
+
+        EndpointFilterDelegate next = _ => ValueTask.FromResult<object?>(null);
+        var filter = new ValidationFilter<NewRecipe>();
+
+        Func<Task> act = async () => await filter.InvokeAsync(context, next);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/MenuApi.Tests/Validation/ValidationFilterTests.cs
+++ b/MenuApi.Tests/Validation/ValidationFilterTests.cs
@@ -1,5 +1,4 @@
 #nullable enable
-#nullable enable
 
 using AwesomeAssertions;
 using FakeItEasy;

--- a/MenuApi/Exceptions/BusinessValidationException.cs
+++ b/MenuApi/Exceptions/BusinessValidationException.cs
@@ -1,0 +1,6 @@
+namespace MenuApi.Exceptions;
+
+public class BusinessValidationException : Exception
+{
+    public BusinessValidationException(string message) : base(message) { }
+}

--- a/MenuApi/Exceptions/BusinessValidationExceptionHandler.cs
+++ b/MenuApi/Exceptions/BusinessValidationExceptionHandler.cs
@@ -14,6 +14,7 @@ public class BusinessValidationExceptionHandler : IExceptionHandler
             return false;
 
         httpContext.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+        httpContext.Response.ContentType = "application/problem+json";
 
         await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
         {

--- a/MenuApi/Exceptions/BusinessValidationExceptionHandler.cs
+++ b/MenuApi/Exceptions/BusinessValidationExceptionHandler.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MenuApi.Exceptions;
+
+public class BusinessValidationExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not BusinessValidationException bve)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status422UnprocessableEntity,
+            Title = "Unprocessable Entity",
+            Detail = bve.Message,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.21"
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/MenuApi/MenuApi.csproj
+++ b/MenuApi/MenuApi.csproj
@@ -31,6 +31,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.0" />
+		<PackageReference Include="FluentValidation" Version="12.1.1" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MenuApi/Program.cs
+++ b/MenuApi/Program.cs
@@ -1,6 +1,8 @@
 using Menu.ApiServiceDefaults;
+using FluentValidation;
 using MenuDB;
 using MenuApi;
+using MenuApi.Exceptions;
 using MenuApi.Recipes;
 using MenuApi.Repositories;
 using MenuApi.Services;
@@ -20,6 +22,10 @@ builder.Services.AddTransient<IIngredientService, IngredientService>();
 
 builder.Services.AddTransient<IRecipeRepository, RecipeRepository>();
 builder.Services.AddTransient<IRecipeService, RecipeService>();
+
+builder.Services.AddExceptionHandler<BusinessValidationExceptionHandler>();
+
+builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 
 builder.AddSqlServerDbContext<MenuDbContext>("menu");
 

--- a/MenuApi/Recipes/IngredientApi.cs
+++ b/MenuApi/Recipes/IngredientApi.cs
@@ -13,9 +13,11 @@ public static class IngredientApi
 
         group.WithTags("Ingredients");
 
-        group.MapGet("/", GetIngredientsAsync);
+        group.MapGet("/", GetIngredientsAsync)
+            .Produces<IEnumerable<ViewModel.Ingredient>>(StatusCodes.Status200OK);
 
-        group.MapGet("/unit", GetIngredientUnitsAsync);
+        group.MapGet("/unit", GetIngredientUnitsAsync)
+            .Produces<IEnumerable<ViewModel.IngredientUnit>>(StatusCodes.Status200OK);
 
         group.MapPost("/", CreateIngredientAsync)
             .AddEndpointFilter<ValidationFilter<NewIngredient>>()

--- a/MenuApi/Recipes/IngredientApi.cs
+++ b/MenuApi/Recipes/IngredientApi.cs
@@ -1,5 +1,6 @@
 ﻿﻿using MenuApi.Repositories;
 using MenuApi.Services;
+using MenuApi.Validation;
 using MenuApi.ViewModel;
 
 namespace MenuApi.Recipes;
@@ -16,7 +17,10 @@ public static class IngredientApi
 
         group.MapGet("/unit", GetIngredientUnitsAsync);
 
-        group.MapPost("/", CreateIngredientAsync);
+        group.MapPost("/", CreateIngredientAsync)
+            .AddEndpointFilter<ValidationFilter<NewIngredient>>()
+            .Produces<ViewModel.Ingredient>(StatusCodes.Status200OK)
+            .ProducesValidationProblem();
 
         return group;
     }

--- a/MenuApi/Recipes/RecipeApi.cs
+++ b/MenuApi/Recipes/RecipeApi.cs
@@ -1,4 +1,5 @@
 ﻿using MenuApi.Services;
+using MenuApi.Validation;
 using MenuApi.ValueObjects;
 using MenuApi.ViewModel;
 
@@ -14,13 +15,22 @@ public static class RecipeApi
 
         group.MapGet("/", GetRecipesAsync);
 
-        group.MapGet("/{recipeId}", GetRecipeAsync);
+        group.MapGet("/{recipeId}", GetRecipeAsync)
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapGet("/{recipeId}/ingredient", GetRecipeIngredientsAsync);
 
-        group.MapPost("/", CreateRecipeAsync);
+        group.MapPost("/", CreateRecipeAsync)
+            .AddEndpointFilter<ValidationFilter<NewRecipe>>()
+            .Produces<FullRecipe>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
 
-        group.MapPut("{recipeId}", UpdateRecipeAsync);
+        group.MapPut("{recipeId}", UpdateRecipeAsync)
+            .AddEndpointFilter<ValidationFilter<NewRecipe>>()
+            .Produces<FullRecipe>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
 
         return group;
     }
@@ -30,9 +40,14 @@ public static class RecipeApi
         return await recipeService.GetRecipesAsync();
     }
 
-    public static async Task<FullRecipe?> GetRecipeAsync(IRecipeService recipeService, RecipeId recipeId)
+    public static async Task<IResult> GetRecipeAsync(IRecipeService recipeService, RecipeId recipeId)
     {
-        return await recipeService.GetRecipeAsync(recipeId);
+        var recipe = await recipeService.GetRecipeAsync(recipeId);
+        return recipe is not null
+            ? Results.Ok(recipe)
+            : Results.Problem(
+                detail: $"Recipe with ID {recipeId} was not found.",
+                statusCode: StatusCodes.Status404NotFound);
     }
 
     public static async Task<IEnumerable<RecipeIngredient>> GetRecipeIngredientsAsync(IRecipeService recipeService, RecipeId recipeId)

--- a/MenuApi/Recipes/RecipeApi.cs
+++ b/MenuApi/Recipes/RecipeApi.cs
@@ -13,12 +13,15 @@ public static class RecipeApi
 
         group.WithTags("Recipes");
 
-        group.MapGet("/", GetRecipesAsync);
+        group.MapGet("/", GetRecipesAsync)
+            .Produces<IEnumerable<Recipe>>(StatusCodes.Status200OK);
 
         group.MapGet("/{recipeId}", GetRecipeAsync)
+            .Produces<FullRecipe>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
-        group.MapGet("/{recipeId}/ingredient", GetRecipeIngredientsAsync);
+        group.MapGet("/{recipeId}/ingredient", GetRecipeIngredientsAsync)
+            .Produces<IEnumerable<RecipeIngredient>>(StatusCodes.Status200OK);
 
         group.MapPost("/", CreateRecipeAsync)
             .AddEndpointFilter<ValidationFilter<NewRecipe>>()

--- a/MenuApi/Repositories/RecipeRepository.cs
+++ b/MenuApi/Repositories/RecipeRepository.cs
@@ -2,6 +2,7 @@
 using MenuDB;
 using MenuDB.Data;
 using MenuApi.DBModel;
+using MenuApi.Exceptions;
 using MenuApi.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 
@@ -87,9 +88,9 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
         foreach (var item in incoming)
         {
             if (!ingredientLookup.TryGetValue(item.IngredientName.Value, out var ingredientId))
-                throw new InvalidOperationException($"Ingredient '{item.IngredientName.Value}' does not exist.");
+                throw new BusinessValidationException($"Ingredient '{item.IngredientName.Value}' does not exist.");
             if (!unitLookup.TryGetValue(item.UnitName.Value, out var unitId))
-                throw new InvalidOperationException($"Unit '{item.UnitName.Value}' does not exist.");
+                throw new BusinessValidationException($"Unit '{item.UnitName.Value}' does not exist.");
 
             var existingRow = existing.FirstOrDefault(e => e.IngredientId == ingredientId && e.UnitId == unitId);
             if (existingRow is not null)

--- a/MenuApi/Validation/NewIngredientValidator.cs
+++ b/MenuApi/Validation/NewIngredientValidator.cs
@@ -9,12 +9,12 @@ public class NewIngredientValidator : AbstractValidator<NewIngredient>
     {
         RuleFor(x => x.Name.Value)
             .NotEmpty()
-            .WithName("Name")
+            .OverridePropertyName("Name")
             .WithMessage("'Name' must not be empty.");
 
         RuleFor(x => x.Name.Value)
             .MaximumLength(50)
-            .WithName("Name")
+            .OverridePropertyName("Name")
             .WithMessage("'Name' must be 50 characters or fewer.");
 
         RuleFor(x => x.UnitIds)

--- a/MenuApi/Validation/NewIngredientValidator.cs
+++ b/MenuApi/Validation/NewIngredientValidator.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+using MenuApi.ViewModel;
+
+namespace MenuApi.Validation;
+
+public class NewIngredientValidator : AbstractValidator<NewIngredient>
+{
+    public NewIngredientValidator()
+    {
+        RuleFor(x => x.Name.Value)
+            .NotEmpty()
+            .WithName("Name")
+            .WithMessage("'Name' must not be empty.");
+
+        RuleFor(x => x.Name.Value)
+            .MaximumLength(50)
+            .WithName("Name")
+            .WithMessage("'Name' must be 50 characters or fewer.");
+
+        RuleFor(x => x.UnitIds)
+            .NotNull()
+            .WithMessage("'Unit Ids' must not be empty.");
+
+        RuleFor(x => x.UnitIds)
+            .Must(u => u is { Count: > 0 })
+            .When(x => x.UnitIds is not null)
+            .WithMessage("'Unit Ids' must not be empty.");
+
+        RuleForEach(x => x.UnitIds)
+            .GreaterThan(0)
+            .WithMessage("Each unit ID must be greater than 0.");
+    }
+}

--- a/MenuApi/Validation/NewIngredientValidator.cs
+++ b/MenuApi/Validation/NewIngredientValidator.cs
@@ -14,12 +14,12 @@ public class NewIngredientValidator : AbstractValidator<NewIngredient>
 
         RuleFor(x => x.UnitIds)
             .NotNull()
-            .WithMessage("'Unit Ids' must not be empty.");
+            .WithMessage("'UnitIds' must not be empty.");
 
         RuleFor(x => x.UnitIds)
             .Must(u => u is { Count: > 0 })
             .When(x => x.UnitIds is not null)
-            .WithMessage("'Unit Ids' must not be empty.");
+            .WithMessage("'UnitIds' must not be empty.");
 
         RuleForEach(x => x.UnitIds)
             .GreaterThan(0)

--- a/MenuApi/Validation/NewIngredientValidator.cs
+++ b/MenuApi/Validation/NewIngredientValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using MenuApi.ValueObjects;
 using MenuApi.ViewModel;
 
 namespace MenuApi.Validation;
@@ -7,22 +8,9 @@ public class NewIngredientValidator : AbstractValidator<NewIngredient>
 {
     public NewIngredientValidator()
     {
-        RuleFor(x => x.Name)
-            .Must(name => name.IsInitialized())
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must not be empty.");
-
-        RuleFor(x => x.Name.Value)
-            .NotEmpty()
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must not be empty.")
-            .When(x => x.Name.IsInitialized());
-
-        RuleFor(x => x.Name.Value)
-            .MaximumLength(50)
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must be 50 characters or fewer.")
-            .When(x => x.Name.IsInitialized());
+        Include(VogenValidationRules.StringRules<NewIngredient, IngredientName>(
+            x => x.Name, x => x.Name.Value,
+            x => x.Name.IsInitialized(), "Name", 50));
 
         RuleFor(x => x.UnitIds)
             .NotNull()

--- a/MenuApi/Validation/NewIngredientValidator.cs
+++ b/MenuApi/Validation/NewIngredientValidator.cs
@@ -7,15 +7,22 @@ public class NewIngredientValidator : AbstractValidator<NewIngredient>
 {
     public NewIngredientValidator()
     {
-        RuleFor(x => x.Name.Value)
-            .NotEmpty()
+        RuleFor(x => x.Name)
+            .Must(name => name.IsInitialized())
             .OverridePropertyName("Name")
             .WithMessage("'Name' must not be empty.");
 
         RuleFor(x => x.Name.Value)
+            .NotEmpty()
+            .OverridePropertyName("Name")
+            .WithMessage("'Name' must not be empty.")
+            .When(x => x.Name.IsInitialized());
+
+        RuleFor(x => x.Name.Value)
             .MaximumLength(50)
             .OverridePropertyName("Name")
-            .WithMessage("'Name' must be 50 characters or fewer.");
+            .WithMessage("'Name' must be 50 characters or fewer.")
+            .When(x => x.Name.IsInitialized());
 
         RuleFor(x => x.UnitIds)
             .NotNull()

--- a/MenuApi/Validation/NewRecipeValidator.cs
+++ b/MenuApi/Validation/NewRecipeValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using MenuApi.ViewModel;
+
+namespace MenuApi.Validation;
+
+public class NewRecipeValidator : AbstractValidator<NewRecipe>
+{
+    public NewRecipeValidator()
+    {
+        RuleFor(x => x.Name.Value)
+            .NotEmpty()
+            .WithName("Name")
+            .WithMessage("'Name' must not be empty.");
+
+        RuleFor(x => x.Name.Value)
+            .MaximumLength(500)
+            .WithName("Name")
+            .WithMessage("'Name' must be 500 characters or fewer.");
+
+        RuleFor(x => x.Ingredients)
+            .NotNull()
+            .WithMessage("'Ingredients' must not be empty.");
+
+        RuleFor(x => x.Ingredients)
+            .Must(i => i is { Count: > 0 })
+            .When(x => x.Ingredients is not null)
+            .WithMessage("'Ingredients' must not be empty.");
+
+        RuleForEach(x => x.Ingredients)
+            .SetValidator(new RecipeIngredientValidator());
+    }
+}

--- a/MenuApi/Validation/NewRecipeValidator.cs
+++ b/MenuApi/Validation/NewRecipeValidator.cs
@@ -7,15 +7,22 @@ public class NewRecipeValidator : AbstractValidator<NewRecipe>
 {
     public NewRecipeValidator()
     {
-        RuleFor(x => x.Name.Value)
-            .NotEmpty()
+        RuleFor(x => x.Name)
+            .Must(name => name.IsInitialized())
             .OverridePropertyName("Name")
             .WithMessage("'Name' must not be empty.");
 
         RuleFor(x => x.Name.Value)
+            .NotEmpty()
+            .OverridePropertyName("Name")
+            .WithMessage("'Name' must not be empty.")
+            .When(x => x.Name.IsInitialized());
+
+        RuleFor(x => x.Name.Value)
             .MaximumLength(500)
             .OverridePropertyName("Name")
-            .WithMessage("'Name' must be 500 characters or fewer.");
+            .WithMessage("'Name' must be 500 characters or fewer.")
+            .When(x => x.Name.IsInitialized());
 
         RuleFor(x => x.Ingredients)
             .NotNull()

--- a/MenuApi/Validation/NewRecipeValidator.cs
+++ b/MenuApi/Validation/NewRecipeValidator.cs
@@ -9,12 +9,12 @@ public class NewRecipeValidator : AbstractValidator<NewRecipe>
     {
         RuleFor(x => x.Name.Value)
             .NotEmpty()
-            .WithName("Name")
+            .OverridePropertyName("Name")
             .WithMessage("'Name' must not be empty.");
 
         RuleFor(x => x.Name.Value)
             .MaximumLength(500)
-            .WithName("Name")
+            .OverridePropertyName("Name")
             .WithMessage("'Name' must be 500 characters or fewer.");
 
         RuleFor(x => x.Ingredients)

--- a/MenuApi/Validation/NewRecipeValidator.cs
+++ b/MenuApi/Validation/NewRecipeValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using MenuApi.ValueObjects;
 using MenuApi.ViewModel;
 
 namespace MenuApi.Validation;
@@ -7,22 +8,9 @@ public class NewRecipeValidator : AbstractValidator<NewRecipe>
 {
     public NewRecipeValidator()
     {
-        RuleFor(x => x.Name)
-            .Must(name => name.IsInitialized())
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must not be empty.");
-
-        RuleFor(x => x.Name.Value)
-            .NotEmpty()
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must not be empty.")
-            .When(x => x.Name.IsInitialized());
-
-        RuleFor(x => x.Name.Value)
-            .MaximumLength(500)
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must be 500 characters or fewer.")
-            .When(x => x.Name.IsInitialized());
+        Include(VogenValidationRules.StringRules<NewRecipe, RecipeName>(
+            x => x.Name, x => x.Name.Value,
+            x => x.Name.IsInitialized(), "Name", 500));
 
         RuleFor(x => x.Ingredients)
             .NotNull()

--- a/MenuApi/Validation/RecipeIngredientValidator.cs
+++ b/MenuApi/Validation/RecipeIngredientValidator.cs
@@ -1,0 +1,40 @@
+using FluentValidation;
+using MenuApi.ViewModel;
+
+namespace MenuApi.Validation;
+
+public class RecipeIngredientValidator : AbstractValidator<RecipeIngredient>
+{
+    public RecipeIngredientValidator()
+    {
+        RuleFor(x => x.Name.Value)
+            .NotEmpty()
+            .WithName("Name")
+            .WithMessage("'Name' must not be empty.");
+
+        RuleFor(x => x.Name.Value)
+            .MaximumLength(50)
+            .WithName("Name")
+            .WithMessage("'Name' must be 50 characters or fewer.");
+
+        RuleFor(x => x.Unit.Value)
+            .NotEmpty()
+            .WithName("Unit")
+            .WithMessage("'Unit' must not be empty.");
+
+        RuleFor(x => x.Unit.Value)
+            .MaximumLength(50)
+            .WithName("Unit")
+            .WithMessage("'Unit' must be 50 characters or fewer.");
+
+        RuleFor(x => x.Amount.Value)
+            .GreaterThan(0)
+            .WithName("Amount")
+            .WithMessage("'Amount' must be greater than '0'.");
+
+        RuleFor(x => x.Amount.Value)
+            .PrecisionScale(10, 4, ignoreTrailingZeros: true)
+            .WithName("Amount")
+            .WithMessage("'Amount' must have at most 10 digits total, with 4 decimal places.");
+    }
+}

--- a/MenuApi/Validation/RecipeIngredientValidator.cs
+++ b/MenuApi/Validation/RecipeIngredientValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using MenuApi.ValueObjects;
 using MenuApi.ViewModel;
 
 namespace MenuApi.Validation;
@@ -7,39 +8,13 @@ public class RecipeIngredientValidator : AbstractValidator<RecipeIngredient>
 {
     public RecipeIngredientValidator()
     {
-        RuleFor(x => x.Name)
-            .Must(name => name.IsInitialized())
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must not be empty.");
+        Include(VogenValidationRules.StringRules<RecipeIngredient, IngredientName>(
+            x => x.Name, x => x.Name.Value,
+            x => x.Name.IsInitialized(), "Name", 50));
 
-        RuleFor(x => x.Name.Value)
-            .NotEmpty()
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must not be empty.")
-            .When(x => x.Name.IsInitialized());
-
-        RuleFor(x => x.Name.Value)
-            .MaximumLength(50)
-            .OverridePropertyName("Name")
-            .WithMessage("'Name' must be 50 characters or fewer.")
-            .When(x => x.Name.IsInitialized());
-
-        RuleFor(x => x.Unit)
-            .Must(unit => unit.IsInitialized())
-            .OverridePropertyName("Unit")
-            .WithMessage("'Unit' must not be empty.");
-
-        RuleFor(x => x.Unit.Value)
-            .NotEmpty()
-            .OverridePropertyName("Unit")
-            .WithMessage("'Unit' must not be empty.")
-            .When(x => x.Unit.IsInitialized());
-
-        RuleFor(x => x.Unit.Value)
-            .MaximumLength(50)
-            .OverridePropertyName("Unit")
-            .WithMessage("'Unit' must be 50 characters or fewer.")
-            .When(x => x.Unit.IsInitialized());
+        Include(VogenValidationRules.StringRules<RecipeIngredient, IngredientUnitName>(
+            x => x.Unit, x => x.Unit.Value,
+            x => x.Unit.IsInitialized(), "Unit", 50));
 
         RuleFor(x => x.Amount)
             .Must(amount => amount.IsInitialized())

--- a/MenuApi/Validation/RecipeIngredientValidator.cs
+++ b/MenuApi/Validation/RecipeIngredientValidator.cs
@@ -9,32 +9,32 @@ public class RecipeIngredientValidator : AbstractValidator<RecipeIngredient>
     {
         RuleFor(x => x.Name.Value)
             .NotEmpty()
-            .WithName("Name")
+            .OverridePropertyName("Name")
             .WithMessage("'Name' must not be empty.");
 
         RuleFor(x => x.Name.Value)
             .MaximumLength(50)
-            .WithName("Name")
+            .OverridePropertyName("Name")
             .WithMessage("'Name' must be 50 characters or fewer.");
 
         RuleFor(x => x.Unit.Value)
             .NotEmpty()
-            .WithName("Unit")
+            .OverridePropertyName("Unit")
             .WithMessage("'Unit' must not be empty.");
 
         RuleFor(x => x.Unit.Value)
             .MaximumLength(50)
-            .WithName("Unit")
+            .OverridePropertyName("Unit")
             .WithMessage("'Unit' must be 50 characters or fewer.");
 
         RuleFor(x => x.Amount.Value)
             .GreaterThan(0)
-            .WithName("Amount")
+            .OverridePropertyName("Amount")
             .WithMessage("'Amount' must be greater than '0'.");
 
         RuleFor(x => x.Amount.Value)
             .PrecisionScale(10, 4, ignoreTrailingZeros: true)
-            .WithName("Amount")
+            .OverridePropertyName("Amount")
             .WithMessage("'Amount' must have at most 10 digits total, with 4 decimal places.");
     }
 }

--- a/MenuApi/Validation/RecipeIngredientValidator.cs
+++ b/MenuApi/Validation/RecipeIngredientValidator.cs
@@ -44,7 +44,7 @@ public class RecipeIngredientValidator : AbstractValidator<RecipeIngredient>
         RuleFor(x => x.Amount)
             .Must(amount => amount.IsInitialized())
             .OverridePropertyName("Amount")
-            .WithMessage("'Amount' must be greater than '0'.");
+            .WithMessage("'Amount' must not be empty.");
 
         RuleFor(x => x.Amount.Value)
             .GreaterThan(0)

--- a/MenuApi/Validation/RecipeIngredientValidator.cs
+++ b/MenuApi/Validation/RecipeIngredientValidator.cs
@@ -7,34 +7,55 @@ public class RecipeIngredientValidator : AbstractValidator<RecipeIngredient>
 {
     public RecipeIngredientValidator()
     {
-        RuleFor(x => x.Name.Value)
-            .NotEmpty()
+        RuleFor(x => x.Name)
+            .Must(name => name.IsInitialized())
             .OverridePropertyName("Name")
             .WithMessage("'Name' must not be empty.");
 
         RuleFor(x => x.Name.Value)
+            .NotEmpty()
+            .OverridePropertyName("Name")
+            .WithMessage("'Name' must not be empty.")
+            .When(x => x.Name.IsInitialized());
+
+        RuleFor(x => x.Name.Value)
             .MaximumLength(50)
             .OverridePropertyName("Name")
-            .WithMessage("'Name' must be 50 characters or fewer.");
+            .WithMessage("'Name' must be 50 characters or fewer.")
+            .When(x => x.Name.IsInitialized());
 
-        RuleFor(x => x.Unit.Value)
-            .NotEmpty()
+        RuleFor(x => x.Unit)
+            .Must(unit => unit.IsInitialized())
             .OverridePropertyName("Unit")
             .WithMessage("'Unit' must not be empty.");
 
         RuleFor(x => x.Unit.Value)
+            .NotEmpty()
+            .OverridePropertyName("Unit")
+            .WithMessage("'Unit' must not be empty.")
+            .When(x => x.Unit.IsInitialized());
+
+        RuleFor(x => x.Unit.Value)
             .MaximumLength(50)
             .OverridePropertyName("Unit")
-            .WithMessage("'Unit' must be 50 characters or fewer.");
+            .WithMessage("'Unit' must be 50 characters or fewer.")
+            .When(x => x.Unit.IsInitialized());
 
-        RuleFor(x => x.Amount.Value)
-            .GreaterThan(0)
+        RuleFor(x => x.Amount)
+            .Must(amount => amount.IsInitialized())
             .OverridePropertyName("Amount")
             .WithMessage("'Amount' must be greater than '0'.");
 
         RuleFor(x => x.Amount.Value)
+            .GreaterThan(0)
+            .OverridePropertyName("Amount")
+            .WithMessage("'Amount' must be greater than '0'.")
+            .When(x => x.Amount.IsInitialized());
+
+        RuleFor(x => x.Amount.Value)
             .PrecisionScale(10, 4, ignoreTrailingZeros: true)
             .OverridePropertyName("Amount")
-            .WithMessage("'Amount' must have at most 10 digits total, with 4 decimal places.");
+            .WithMessage("'Amount' must have at most 10 digits total, with 4 decimal places.")
+            .When(x => x.Amount.IsInitialized());
     }
 }

--- a/MenuApi/Validation/ValidationFilter.cs
+++ b/MenuApi/Validation/ValidationFilter.cs
@@ -22,7 +22,7 @@ public class ValidationFilter<T> : IEndpointFilter
 
         try
         {
-            var result = await validator.ValidateAsync(argument);
+            var result = await validator.ValidateAsync(argument, context.HttpContext.RequestAborted);
             if (!result.IsValid)
             {
                 return Results.ValidationProblem(

--- a/MenuApi/Validation/ValidationFilter.cs
+++ b/MenuApi/Validation/ValidationFilter.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Vogen;
 
 namespace MenuApi.Validation;
 
@@ -48,6 +49,6 @@ public class ValidationFilter<T> : IEndpointFilter
     }
 
     private static bool IsVogenValueObjectException(Exception ex) =>
-        ex.Message.Contains("uninitialized Value Object", StringComparison.OrdinalIgnoreCase) ||
-        ex.GetType().Name.Contains("ValueObjectValidation", StringComparison.Ordinal);
+        ex is ValueObjectValidationException ||
+        ex.Message.Contains("uninitialized Value Object", StringComparison.OrdinalIgnoreCase);
 }

--- a/MenuApi/Validation/ValidationFilter.cs
+++ b/MenuApi/Validation/ValidationFilter.cs
@@ -9,11 +9,9 @@ public class ValidationFilter<T> : IEndpointFilter
         EndpointFilterInvocationContext context,
         EndpointFilterDelegate next)
     {
-        var validator = context.HttpContext.RequestServices.GetService<IValidator<T>>();
-        if (validator is null)
-            return await next(context);
+        var validator = context.HttpContext.RequestServices.GetRequiredService<IValidator<T>>();
 
-        var argument = context.Arguments.OfType<T>().FirstOrDefault();
+        var argument= context.Arguments.OfType<T>().FirstOrDefault();
         if (argument is null)
             return Results.ValidationProblem(
                 new Dictionary<string, string[]>

--- a/MenuApi/Validation/ValidationFilter.cs
+++ b/MenuApi/Validation/ValidationFilter.cs
@@ -1,0 +1,53 @@
+using FluentValidation;
+
+namespace MenuApi.Validation;
+
+public class ValidationFilter<T> : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var validator = context.HttpContext.RequestServices.GetService<IValidator<T>>();
+        if (validator is null)
+            return await next(context);
+
+        var argument = context.Arguments.OfType<T>().FirstOrDefault();
+        if (argument is null)
+            return Results.ValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["Body"] = ["Request body is required."]
+                });
+
+        try
+        {
+            var result = await validator.ValidateAsync(argument);
+            if (!result.IsValid)
+            {
+                return Results.ValidationProblem(
+                    result.Errors
+                        .GroupBy(e => e.PropertyName)
+                        .ToDictionary(
+                            g => g.Key,
+                            g => g.Select(e => e.ErrorMessage).ToArray()));
+            }
+        }
+        catch (Exception ex) when (IsVogenValueObjectException(ex))
+        {
+            // Vogen value objects throw when accessing .Value on uninitialized structs
+            // (e.g. missing properties in JSON). Treat as a validation failure.
+            return Results.ValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["Body"] = ["Request body contains invalid or missing fields."]
+                });
+        }
+
+        return await next(context);
+    }
+
+    private static bool IsVogenValueObjectException(Exception ex) =>
+        ex.Message.Contains("uninitialized Value Object", StringComparison.OrdinalIgnoreCase) ||
+        ex.GetType().Name.Contains("ValueObjectValidation", StringComparison.Ordinal);
+}

--- a/MenuApi/Validation/VogenValidationRules.cs
+++ b/MenuApi/Validation/VogenValidationRules.cs
@@ -1,0 +1,36 @@
+using System.Linq.Expressions;
+using FluentValidation;
+
+namespace MenuApi.Validation;
+
+public static class VogenValidationRules
+{
+    public static InlineValidator<T> StringRules<T, TVogen>(
+        Expression<Func<T, TVogen>> vogenSelector,
+        Expression<Func<T, string>> valueSelector,
+        Func<T, bool> isInitialized,
+        string propertyName,
+        int maxLength) where TVogen : struct
+    {
+        var rules = new InlineValidator<T>();
+
+        rules.RuleFor(vogenSelector)
+            .Must((parent, _) => isInitialized(parent))
+            .OverridePropertyName(propertyName)
+            .WithMessage($"'{propertyName}' must not be empty.");
+
+        rules.RuleFor(valueSelector)
+            .NotEmpty()
+            .OverridePropertyName(propertyName)
+            .WithMessage($"'{propertyName}' must not be empty.")
+            .When(x => isInitialized(x));
+
+        rules.RuleFor(valueSelector)
+            .MaximumLength(maxLength)
+            .OverridePropertyName(propertyName)
+            .WithMessage($"'{propertyName}' must be {maxLength} characters or fewer.")
+            .When(x => isInitialized(x));
+
+        return rules;
+    }
+}

--- a/docs/specs/api-validation.md
+++ b/docs/specs/api-validation.md
@@ -313,13 +313,13 @@ MenuApi/
 │   ├── BusinessValidationException.cs   # Custom exception for 422 responses
 │   └── BusinessValidationExceptionHandler.cs  # IExceptionHandler → 422
 ├── ValueObjects/
-│   ├── RecipeName.cs                    # Add Validate method
-│   ├── RecipeId.cs                      # Add Validate method
-│   ├── IngredientName.cs                # Add Validate method
-│   ├── IngredientId.cs                  # Add Validate method
-│   ├── IngredientAmount.cs              # Add Validate method
-│   ├── IngredientUnitName.cs            # Add Validate method
-│   └── IngredientUnitType.cs            # Add Validate method
+│   ├── RecipeName.cs                    # No Validate method changes
+│   ├── RecipeId.cs                      # No Validate method changes
+│   ├── IngredientName.cs                # No Validate method changes
+│   ├── IngredientId.cs                  # No Validate method changes
+│   ├── IngredientAmount.cs              # No Validate method changes
+│   ├── IngredientUnitName.cs            # No Validate method changes
+│   └── IngredientUnitType.cs            # No Validate method changes
 ├── Recipes/
 │   ├── RecipeApi.cs                     # Add filters, 404 handling, .Produces()
 │   └── IngredientApi.cs                 # Add filters, .Produces()

--- a/docs/specs/api-validation.md
+++ b/docs/specs/api-validation.md
@@ -113,31 +113,32 @@ This is the standard ASP.NET Core validation problem details format produced by 
 
 ## Vogen Value Object Validation
 
-Add `Validate` methods to value objects so they reject invalid values at creation time:
+> **Decision:** Vogen `Validate` methods are **not** added to value objects.
 
-| Value Object | Underlying Type | Validation Rule |
-|---|---|---|
-| `RecipeName` | `string` | Must not be null/empty/whitespace |
-| `IngredientName` | `string` | Must not be null/empty/whitespace |
-| `IngredientAmount` | `decimal` | Must be greater than 0 |
-| `IngredientUnitName` | `string` | Must not be null/empty/whitespace |
-| `IngredientUnitAbbreviation` | `string` | No additional validation (nullable) |
-| `IngredientUnitType` | `string` | Must not be null/empty/whitespace |
-| `RecipeId` | `int` | Must be greater than 0 |
-| `IngredientId` | `int` | Must be greater than 0 |
+Adding `Validate` methods to Vogen value objects (e.g. rejecting empty strings in `RecipeName`) was considered but deliberately avoided. The reason: Vogen's `Validate` runs during deserialization — if validation fails, the JSON deserializer throws before the request reaches FluentValidation. This means:
 
-Vogen supports a static `Validate` method on each value object:
+- The API returns a generic deserialization error instead of a structured RFC 9457 validation response
+- Clients lose the field-specific error messages that FluentValidation provides (e.g. `"Name": ["'Name' must not be empty."]`)
+- Multiple validation errors cannot be reported in a single response
+
+**Actual approach:** Validators use Vogen's generated `IsInitialized()` method to detect uninitialized (missing) value objects and produce field-specific errors before accessing `.Value`:
 
 ```csharp
-[ValueObject<string>]
-public readonly partial struct RecipeName
-{
-    private static Validation Validate(string value) =>
-        string.IsNullOrWhiteSpace(value)
-            ? Validation.Invalid("Recipe name must not be empty.")
-            : Validation.Ok;
-}
+// Check presence first — produces "Name" error if missing
+RuleFor(x => x.Name)
+    .Must(name => name.IsInitialized())
+    .OverridePropertyName("Name")
+    .WithMessage("'Name' must not be empty.");
+
+// Only validate .Value when initialized — avoids Vogen throw
+RuleFor(x => x.Name.Value)
+    .MaximumLength(500)
+    .OverridePropertyName("Name")
+    .WithMessage("'Name' must be 500 characters or fewer.")
+    .When(x => x.Name.IsInitialized());
 ```
+
+The `ValidationFilter` retains a fallback `catch` for `Vogen.ValueObjectValidationException` to handle any remaining edge cases where an uninitialized value object is accessed outside the guarded rules.
 
 ## Endpoint Filter Implementation
 

--- a/docs/specs/api-validation.md
+++ b/docs/specs/api-validation.md
@@ -1,0 +1,358 @@
+# API Request Validation Spec
+
+**Issue:** [#886 — Validation of api requests](https://github.com/dgee2/Menu/issues/886)
+**Status:** Draft
+**Created:** 2026-03-28
+
+## Problem Statement
+
+All API requests should be validated with appropriate responses returned to the caller. Currently:
+
+- ViewModels use only `[Required]` DataAnnotations — no length, range, or format constraints
+- Business logic failures (e.g., referencing a non-existent ingredient) throw `InvalidOperationException` → 500 Internal Server Error
+- `GET /api/recipe/{recipeId}` returns `null` (200) instead of 404 when the recipe doesn't exist
+- Vogen value objects accept any value with no validation (empty strings, negative amounts, etc.)
+
+## Approach
+
+Use **FluentValidation** with Minimal API **endpoint filters** to validate all request DTOs before they reach business logic. Error responses follow **RFC 9457** (Problem Details for HTTP APIs) — the current standard (supersedes RFC 7807). ASP.NET Core's built-in `Results.ValidationProblem()` and `Results.Problem()` already produce RFC 9457-compliant responses.
+
+## HTTP Status Code Strategy
+
+| Scenario | Status Code | Example |
+|---|---|---|
+| Missing/malformed required fields | **400 Bad Request** | Empty recipe name, missing ingredients list |
+| String too long, value out of range | **400 Bad Request** | Recipe name > 500 chars, amount ≤ 0 |
+| Business rule violation | **422 Unprocessable Entity** | Ingredient "X" does not exist, Unit "Y" not found |
+| Resource not found (GET by ID) | **404 Not Found** | `GET /api/recipe/99999` |
+| Valid request, success | **200 OK** / **201 Created** | Normal operation |
+
+## Error Response Format (RFC 9457)
+
+All error responses use the `application/problem+json` content type.
+
+### Validation Error (400)
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "Name": ["'Name' must not be empty."],
+    "Ingredients": ["'Ingredients' must not be empty."]
+  }
+}
+```
+
+This is the standard ASP.NET Core validation problem details format produced by `Results.ValidationProblem()`.
+
+### Business Rule Error (422)
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.21",
+  "title": "Unprocessable Entity",
+  "status": 422,
+  "detail": "Ingredient 'Flour' does not exist."
+}
+```
+
+### Not Found (404)
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.5",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Recipe with ID 99999 was not found."
+}
+```
+
+## Package Dependencies
+
+| Package | Purpose |
+|---|---|
+| `FluentValidation` | Core validation library |
+| `FluentValidation.DependencyInjectionExtensions` | `AddValidatorsFromAssemblyContaining<T>()` for DI registration |
+
+> **Note:** Do _not_ use `FluentValidation.AspNetCore` — it is deprecated and targets MVC. Minimal APIs use endpoint filters instead.
+
+## Validation Rules
+
+### 1. `NewRecipe` Validator
+
+| Property | Rule | Constraint Source |
+|---|---|---|
+| `Name` | Must not be empty/whitespace | Business logic |
+| `Name` | Maximum 500 characters | DB: `Recipe.Name varchar(500)` |
+| `Ingredients` | Must not be null | Required field |
+| `Ingredients` | Must contain at least one item | Business logic — a recipe with no ingredients is meaningless |
+| `Ingredients[*]` | Each item must pass `RecipeIngredientValidator` | Nested validation |
+
+### 2. `RecipeIngredient` Validator
+
+| Property | Rule | Constraint Source |
+|---|---|---|
+| `Name` | Must not be empty/whitespace | Business logic |
+| `Name` | Maximum 50 characters | DB: `Ingredient.Name varchar(50)` |
+| `Unit` | Must not be empty/whitespace | Business logic |
+| `Unit` | Maximum 50 characters | DB: `Unit.Name varchar(50)` |
+| `Amount` | Must be greater than 0 | Business logic — zero/negative amounts are invalid |
+| `Amount` | Must have at most 10 digits total, 4 decimal places | DB: `Amount decimal(10,4)` |
+
+### 3. `NewIngredient` Validator
+
+| Property | Rule | Constraint Source |
+|---|---|---|
+| `Name` | Must not be empty/whitespace | Business logic |
+| `Name` | Maximum 50 characters | DB: `Ingredient.Name varchar(50)` |
+| `UnitIds` | Must not be null | Required field |
+| `UnitIds` | Must contain at least one item | Business logic — an ingredient needs at least one unit |
+| `UnitIds[*]` | Each value must be greater than 0 | DB: IDs are positive integers |
+
+## Vogen Value Object Validation
+
+Add `Validate` methods to value objects so they reject invalid values at creation time:
+
+| Value Object | Underlying Type | Validation Rule |
+|---|---|---|
+| `RecipeName` | `string` | Must not be null/empty/whitespace |
+| `IngredientName` | `string` | Must not be null/empty/whitespace |
+| `IngredientAmount` | `decimal` | Must be greater than 0 |
+| `IngredientUnitName` | `string` | Must not be null/empty/whitespace |
+| `IngredientUnitAbbreviation` | `string` | No additional validation (nullable) |
+| `IngredientUnitType` | `string` | Must not be null/empty/whitespace |
+| `RecipeId` | `int` | Must be greater than 0 |
+| `IngredientId` | `int` | Must be greater than 0 |
+
+Vogen supports a static `Validate` method on each value object:
+
+```csharp
+[ValueObject<string>]
+public readonly partial struct RecipeName
+{
+    private static Validation Validate(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? Validation.Invalid("Recipe name must not be empty.")
+            : Validation.Ok;
+}
+```
+
+## Endpoint Filter Implementation
+
+Create a generic, reusable `ValidationFilter<T>` that:
+
+1. Extracts the `T` argument from the endpoint invocation context
+2. Resolves `IValidator<T>` from DI
+3. Runs validation
+4. Returns `Results.ValidationProblem(errors)` (400) if validation fails
+5. Calls `next(context)` if validation passes
+
+```csharp
+public class ValidationFilter<T> : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var validator = context.HttpContext.RequestServices.GetService<IValidator<T>>();
+        if (validator is null)
+            return await next(context);
+
+        var argument = context.Arguments.OfType<T>().FirstOrDefault();
+        if (argument is null)
+            return Results.ValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["Body"] = ["Request body is required."]
+                });
+
+        var result = await validator.ValidateAsync(argument);
+        if (!result.IsValid)
+        {
+            return Results.ValidationProblem(
+                result.Errors
+                    .GroupBy(e => e.PropertyName)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => g.Select(e => e.ErrorMessage).ToArray()));
+        }
+
+        return await next(context);
+    }
+}
+```
+
+Attach to endpoints:
+
+```csharp
+group.MapPost("/", CreateRecipeAsync)
+    .AddEndpointFilter<ValidationFilter<NewRecipe>>();
+
+group.MapPut("{recipeId}", UpdateRecipeAsync)
+    .AddEndpointFilter<ValidationFilter<NewRecipe>>();
+```
+
+## Endpoint Changes for 404 and 422
+
+### GET endpoints — return 404 for missing resources
+
+**`GET /api/recipe/{recipeId}`** — Currently returns `FullRecipe?` (null → 200). Change to:
+
+```csharp
+public static async Task<IResult> GetRecipeAsync(IRecipeService recipeService, RecipeId recipeId)
+{
+    var recipe = await recipeService.GetRecipeAsync(recipeId);
+    return recipe is not null
+        ? Results.Ok(recipe)
+        : Results.Problem(
+            detail: $"Recipe with ID {recipeId} was not found.",
+            statusCode: StatusCodes.Status404NotFound);
+}
+```
+
+### Business logic errors — return 422 instead of 500
+
+Replace `InvalidOperationException` throws in `RecipeRepository` with a result pattern or custom exception type that the endpoint can catch and convert to 422:
+
+**Option: Custom exception + endpoint filter approach**
+
+Define a `BusinessValidationException`:
+
+```csharp
+public class BusinessValidationException : Exception
+{
+    public BusinessValidationException(string message) : base(message) { }
+}
+```
+
+Register a custom `IExceptionHandler` to map `BusinessValidationException` → 422. ASP.NET Core's `IExceptionHandler` pipeline runs inside `UseExceptionHandler()` and is the idiomatic way to handle specific exception types:
+
+```csharp
+public class BusinessValidationExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not BusinessValidationException bve)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status422UnprocessableEntity,
+            Title = "Unprocessable Entity",
+            Detail = bve.Message,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.21"
+        }, cancellationToken);
+
+        return true;
+    }
+}
+```
+
+Register in `Program.cs`:
+
+```csharp
+builder.Services.AddExceptionHandler<BusinessValidationExceptionHandler>();
+```
+
+The existing `app.UseExceptionHandler()` in `MapDefaultApiEndpoints` will invoke this handler automatically. Unhandled exceptions continue to fall through to the default Problem Details handler (500).
+
+Then change the repository to throw `BusinessValidationException` instead of `InvalidOperationException`:
+
+```csharp
+if (!ingredientLookup.TryGetValue(item.IngredientName.Value, out var ingredientId))
+    throw new BusinessValidationException($"Ingredient '{item.IngredientName.Value}' does not exist.");
+```
+
+## OpenAPI Documentation
+
+Add `.Produces()` and `.ProducesValidationProblem()` to all mutating endpoints so the generated OpenAPI spec documents possible error responses:
+
+```csharp
+group.MapPost("/", CreateRecipeAsync)
+    .AddEndpointFilter<ValidationFilter<NewRecipe>>()
+    .Produces<FullRecipe>(StatusCodes.Status200OK)
+    .ProducesValidationProblem()
+    .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+```
+
+## File Structure
+
+New/modified files:
+
+```
+MenuApi/
+├── Validation/
+│   ├── ValidationFilter.cs              # Generic endpoint filter
+│   ├── NewRecipeValidator.cs            # FluentValidation rules for NewRecipe
+│   ├── RecipeIngredientValidator.cs     # FluentValidation rules for RecipeIngredient
+│   └── NewIngredientValidator.cs        # FluentValidation rules for NewIngredient
+├── Exceptions/
+│   ├── BusinessValidationException.cs   # Custom exception for 422 responses
+│   └── BusinessValidationExceptionHandler.cs  # IExceptionHandler → 422
+├── ValueObjects/
+│   ├── RecipeName.cs                    # Add Validate method
+│   ├── RecipeId.cs                      # Add Validate method
+│   ├── IngredientName.cs                # Add Validate method
+│   ├── IngredientId.cs                  # Add Validate method
+│   ├── IngredientAmount.cs              # Add Validate method
+│   ├── IngredientUnitName.cs            # Add Validate method
+│   └── IngredientUnitType.cs            # Add Validate method
+├── Recipes/
+│   ├── RecipeApi.cs                     # Add filters, 404 handling, .Produces()
+│   └── IngredientApi.cs                 # Add filters, .Produces()
+├── Repositories/
+│   └── RecipeRepository.cs              # Throw BusinessValidationException
+└── Program.cs                           # Register FluentValidation, exception handler, configure ProblemDetails
+```
+
+## Test Requirements
+
+### Unit Tests (MenuApi.Tests)
+
+| Test | Validates |
+|---|---|
+| `NewRecipeValidator_EmptyName_Fails` | Name must not be empty |
+| `NewRecipeValidator_NameTooLong_Fails` | Name max 500 chars |
+| `NewRecipeValidator_EmptyIngredients_Fails` | Ingredients list must have ≥1 item |
+| `NewRecipeValidator_ValidRecipe_Passes` | Happy path |
+| `RecipeIngredientValidator_EmptyName_Fails` | Ingredient name required |
+| `RecipeIngredientValidator_NameTooLong_Fails` | Ingredient name max 50 chars |
+| `RecipeIngredientValidator_EmptyUnit_Fails` | Unit required |
+| `RecipeIngredientValidator_ZeroAmount_Fails` | Amount must be > 0 |
+| `RecipeIngredientValidator_NegativeAmount_Fails` | Amount must be > 0 |
+| `RecipeIngredientValidator_TooManyDecimalPlaces_Fails` | Max 4 decimal places |
+| `RecipeIngredientValidator_ValidIngredient_Passes` | Happy path |
+| `NewIngredientValidator_EmptyName_Fails` | Name required |
+| `NewIngredientValidator_NameTooLong_Fails` | Name max 50 chars |
+| `NewIngredientValidator_EmptyUnitIds_Fails` | UnitIds must have ≥1 item |
+| `NewIngredientValidator_ZeroUnitId_Fails` | UnitIds must be > 0 |
+| `NewIngredientValidator_ValidIngredient_Passes` | Happy path |
+| `ValidationFilter_InvalidRequest_Returns400` | Filter returns ValidationProblem |
+| `ValidationFilter_ValidRequest_CallsNext` | Filter passes through |
+| `ValidationFilter_NullBody_Returns400` | Missing body handled |
+
+### Integration Tests (MenuApi.Integration.Tests)
+
+| Test | Validates |
+|---|---|
+| `CreateRecipe_EmptyBody_Returns400` | Empty/null body → 400 |
+| `CreateRecipe_EmptyName_Returns400WithProblemDetails` | Validation error format is RFC 9457 |
+| `CreateRecipe_NonExistentIngredient_Returns422` | Business rule → 422 |
+| `GetRecipe_NonExistentId_Returns404` | Missing resource → 404 |
+| `CreateIngredient_EmptyName_Returns400` | Validation error |
+| `CreateIngredient_EmptyUnitIds_Returns400` | Validation error |
+| `UpdateRecipe_EmptyName_Returns400` | Validation on PUT |
+| `UpdateRecipe_NonExistentIngredient_Returns422` | Business rule on PUT |
+
+## Migration Notes
+
+- Existing `[Required]` DataAnnotations on ViewModels can remain — they serve as documentation and OpenAPI schema hints. FluentValidation will be the primary validation mechanism at runtime.
+- The `ArgumentNullException.ThrowIfNull()` calls in services can remain as defensive programming guards.
+- All changes are backward-compatible for valid requests — only invalid requests that previously returned 500 will now return 400/404/422.

--- a/docs/specs/api-validation.md
+++ b/docs/specs/api-validation.md
@@ -145,7 +145,7 @@ The `ValidationFilter` retains a fallback `catch` for `Vogen.ValueObjectValidati
 Create a generic, reusable `ValidationFilter<T>` that:
 
 1. Extracts the `T` argument from the endpoint invocation context
-2. Resolves `IValidator<T>` from DI
+2. Resolves `IValidator<T>` from DI (throws if not registered — a missing validator is a misconfiguration)
 3. Runs validation
 4. Returns `Results.ValidationProblem(errors)` (400) if validation fails
 5. Calls `next(context)` if validation passes
@@ -157,11 +157,9 @@ public class ValidationFilter<T> : IEndpointFilter
         EndpointFilterInvocationContext context,
         EndpointFilterDelegate next)
     {
-        var validator = context.HttpContext.RequestServices.GetService<IValidator<T>>();
-        if (validator is null)
-            return await next(context);
+        var validator = context.HttpContext.RequestServices.GetRequiredService<IValidator<T>>();
 
-        var argument = context.Arguments.OfType<T>().FirstOrDefault();
+        var argument= context.Arguments.OfType<T>().FirstOrDefault();
         if (argument is null)
             return Results.ValidationProblem(
                 new Dictionary<string, string[]>

--- a/docs/specs/api-validation.md
+++ b/docs/specs/api-validation.md
@@ -169,19 +169,34 @@ public class ValidationFilter<T> : IEndpointFilter
                     ["Body"] = ["Request body is required."]
                 });
 
-        var result = await validator.ValidateAsync(argument);
-        if (!result.IsValid)
+        try
+        {
+            var result = await validator.ValidateAsync(argument, context.HttpContext.RequestAborted);
+            if (!result.IsValid)
+            {
+                return Results.ValidationProblem(
+                    result.Errors
+                        .GroupBy(e => e.PropertyName)
+                        .ToDictionary(
+                            g => g.Key,
+                            g => g.Select(e => e.ErrorMessage).ToArray()));
+            }
+        }
+        catch (Exception ex) when (IsVogenValueObjectException(ex))
         {
             return Results.ValidationProblem(
-                result.Errors
-                    .GroupBy(e => e.PropertyName)
-                    .ToDictionary(
-                        g => g.Key,
-                        g => g.Select(e => e.ErrorMessage).ToArray()));
+                new Dictionary<string, string[]>
+                {
+                    ["Body"] = ["Request body contains invalid or missing fields."]
+                });
         }
 
         return await next(context);
     }
+
+    private static bool IsVogenValueObjectException(Exception ex) =>
+        ex is ValueObjectValidationException ||
+        ex.Message.Contains("uninitialized Value Object", StringComparison.OrdinalIgnoreCase);
 }
 ```
 


### PR DESCRIPTION
## Summary

Implements API request validation per the spec in \docs/specs/api-validation.md\.

### Changes

**FluentValidation with endpoint filters:**
- \ValidationFilter\ — generic endpoint filter that validates request bodies and returns RFC 9457 \ValidationProblem\ (400) responses
- \NewRecipeValidator\ — name required (max 500 chars), at least one ingredient
- \RecipeIngredientValidator\ — name/unit required (max 50 chars), amount > 0 with precision constraints
- \NewIngredientValidator\ — name required (max 50 chars), at least one unit ID

**BusinessValidationException (422):**
- Custom exception for domain-level validation errors (e.g. referencing non-existent ingredients)
- \BusinessValidationExceptionHandler\ maps to RFC 9457 Problem Details with status 422
- \RecipeRepository\ now throws \BusinessValidationException\ instead of \InvalidOperationException\

**404 handling:**
- \GET /api/recipe/{recipeId}\ returns 404 Problem Details when recipe not found

**OpenAPI metadata:**
- Added \.Produces()\, \.ProducesValidationProblem()\, \.ProducesProblem()\ to all endpoints

### Tests
- **29 unit tests**: Validator tests, ValidationFilter tests, updated RecipeApiTests
- **21 integration tests**: 8 new validation tests (400/404/422), existing tests updated for ingredient requirement

Closes #886

### Design Decisions

**Vogen Validate methods not implemented:** The spec originally planned to add `Validate` methods to Vogen value objects, but this was deliberately avoided. Vogen validation runs during deserialization, which would cause failures before FluentValidation runs — losing field-specific error messages. Instead, validators use `IsInitialized()` to detect uninitialized structs and produce proper validation errors.