### PR TITLE
Update simple .NET dependencies

### DIFF
--- a/backend/Menu.ServiceDefaults/Menu.ServiceDefaults.csproj
+++ b/backend/Menu.ServiceDefaults/Menu.ServiceDefaults.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />

--- a/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
+++ b/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
@@ -28,10 +28,13 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
 		<PackageReference Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
-		<PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
+		<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.1" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 	</ItemGroup>
 

--- a/backend/MenuApi.Tests/MenuApi.Tests.csproj
+++ b/backend/MenuApi.Tests/MenuApi.Tests.csproj
@@ -30,14 +30,14 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="8.0.1">
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FakeItEasy" Version="9.0.1" />
-		<PackageReference Include="GitHubActionsTestLogger" Version="3.0.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.1" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 	</ItemGroup>
 

--- a/backend/MenuApi/MenuApi.csproj
+++ b/backend/MenuApi/MenuApi.csproj
@@ -33,13 +33,13 @@
 		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.0" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.5">
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.7">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/backend/MenuDB/MenuDB.csproj
+++ b/backend/MenuDB/MenuDB.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary
This pull request groups the current non-`aspire` NuGet updates that are still pending on `main` and validated as version-only changes. The `aspire` packages were intentionally split into a separate tool-driven branch so this PR stays a simple version bump.

## Classification
This is a `simple version bump`.

## Grouping Rationale
These dependencies were grouped together because they are the current pending `.NET / NuGet` updates outside the named `aspire` group and they only required package version changes in project files.

## Best-Practice Change
No new best-practice change was introduced or required by these updates.
Decision: `do not implement now` because no additional source or workflow changes were needed beyond the package version bumps.

## Validation
Succeeded:
- `cd backend`
- `dotnet workload install aspire`
- `dotnet restore MenuApi.sln`
- `dotnet build MenuApi.sln --configuration Release --no-restore`
- `dotnet test --project MenuApi.Tests/MenuApi.Tests.csproj --configuration Release --no-build`