### PR TITLE
Update Aspire dependencies

### DIFF
--- a/backend/Menu.AppHost/Menu.AppHost.csproj
+++ b/backend/Menu.AppHost/Menu.AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.2.0" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.2.0" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.2.0" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.2.4" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.JavaScript.Extensions" Version="13.1.1" />
   </ItemGroup>
 

--- a/backend/Menu.AppHost/Menu.AppHost.csproj
+++ b/backend/Menu.AppHost/Menu.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/backend/Menu.MigrationService/Menu.MigrationService.csproj
+++ b/backend/Menu.MigrationService/Menu.MigrationService.csproj
@@ -9,7 +9,7 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
+++ b/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.2.4" />		
+		<PackageReference Include="Aspire.Hosting.Testing" Version="13.2.4" />
 		<PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />		
 		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />		
 		<PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8">

--- a/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
+++ b/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.2.0" />		
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.2.4" />		
 		<PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />		
 		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />		
 		<PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8">

--- a/backend/MenuApi/MenuApi.csproj
+++ b/backend/MenuApi/MenuApi.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.0" />
+		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.4" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">


### PR DESCRIPTION
## Summary
This pull request groups the current pending `aspire` NuGet updates on `main` into their own branch. The repository policy treats the `aspire` group separately from other `.NET` updates so the supporting tool step can be considered independently.

## Classification
This is a `tool-driven update`.

## Grouping Rationale
These dependencies were grouped together because they are the pending members of the named `aspire` NuGet group, and that group is handled separately from simple version bumps in this repository.

## Best-Practice Change
The required validation step now warns that `dotnet workload install aspire` is deprecated because Aspire is distributed as NuGet packages.
Decision: `do not implement now` because the repository's current dependency-update validation policy still explicitly requires that command, and these package updates did not otherwise require workflow or source changes.

## Validation
Succeeded:
- `cd backend`
- `dotnet workload install aspire`
- `dotnet restore MenuApi.sln`
- `dotnet build MenuApi.sln --configuration Release --no-restore`
- `dotnet test --project MenuApi.Tests/MenuApi.Tests.csproj --configuration Release --no-build`