### PR TITLE
Bump GitHub Actions: checkout/setup-node to v6, upload-artifact to v7, download-artifact to v8, cache to v5

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.x'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Check for file changes
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -91,7 +91,7 @@ jobs:
         working-directory: ./backend
 
       - name: Upload OpenAPI document
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openapi-spec
           path: open-api/menu-api.json
@@ -197,7 +197,7 @@ jobs:
 
       - name: Download OpenAPI document
         if: needs.backend-build.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openapi-spec
           path: open-api
@@ -237,7 +237,7 @@ jobs:
         working-directory: ./ui/menu-website
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright


### PR DESCRIPTION
## Why these dependencies were grouped together

All updated actions are first-party GitHub Actions infrastructure used across `main.yml` and `dependency-update.yml`. They are updated together as a single simple version-bump PR because none require code changes — only the `@vN` tag references need updating. The `dorny/paths-filter` SHA pin was not changed (it already pointed to `v4.0.1`); only the adjacent comment was corrected from `# v3.0.2` to `# v4.0.1`.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-node` | `v4` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `actions/cache` | `v4` | `v5` |

## Update type

This is a **simple version bump** — only action `@vN` references in workflow YAML files were changed; no source code or configuration required updating.

## Best-practice changes

No best-practice change was introduced or suggested by this update. **Decision: do not implement now.**

## Validation

The following commands were run and succeeded:

```
# YAML syntax check (no tab characters found)  ✅
cd worktrees/copilot-dependency-update-github-actions-simple/ui/menu-website
pnpm install --frozen-lockfile    ✅
pnpm run generate-openapi         ✅
pnpm run lint                     ✅
pnpm run build                    ✅ built in 851ms
```