### PR TITLE
Prevent duplicate inserts for set-like child/link rows

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -25,3 +25,6 @@
 - Backend code lives under `backend/`.
 - Recipe persistence and API behavior are core product responsibilities.
 - Duplicate handling work is sequenced: service/repo logic → schema constraints → API contract.
+- Exact duplicate handling for set-like writes now normalizes request payloads in `backend/MenuApi/Services/IngredientService.cs` and `backend/MenuApi/Services/RecipeService.cs` before repository calls.
+- Repository write paths also stay defensive: `backend/MenuApi/Repositories/IngredientRepository.cs` deduplicates `UnitIds`, and `backend/MenuApi/Repositories/RecipeRepository.cs` deduplicates exact `RecipeIngredient` records before upsert.
+- Regression coverage for duplicate-equivalent write requests lives in `backend/MenuApi.Tests/Services/IngredientServiceTests.cs`, `backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs`, `backend/MenuApi.Tests/Services/RecipeServiceTests.cs`, `backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs`, and `backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs`.

--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -1,0 +1,27 @@
+# Project Context
+
+- **Owner:** Daniel Gee
+- **Project:** Menu
+- **Stack:** Vue 3, Quasar, TypeScript, C#/.NET, EF Core, Aspire
+- **Description:** Recipe management app for customers to save and access recipes easily.
+- **Created:** 2026-05-03T21:34:28.467+01:00
+
+## Team Assignments (2026-05-03)
+
+### Active Work
+
+**Issues:** #977, #978, #979, #980 (duplicate prevention epic)
+
+- **#977** (Prevent duplicate inserts — set-like) — In Progress
+- **#978** (Prevent duplicate inserts — canonical) — Ready when #977 complete
+- **#979** (Add uniqueness constraints) — Depends on #977/#978
+- **#980** (Expose explicit duplicate conflicts) — Final step
+
+**Label:** `squad:basher`
+
+## Learnings
+
+- Backend stack is C#/.NET with Aspire orchestration.
+- Backend code lives under `backend/`.
+- Recipe persistence and API behavior are core product responsibilities.
+- Duplicate handling work is sequenced: service/repo logic → schema constraints → API contract.

--- a/.squad/agents/yen/history.md
+++ b/.squad/agents/yen/history.md
@@ -1,0 +1,25 @@
+# Project Context
+
+- **Owner:** Daniel Gee
+- **Project:** Menu
+- **Stack:** Vue 3, Quasar, TypeScript, C#/.NET, EF Core, Aspire
+- **Description:** Recipe management app for customers to save and access recipes easily.
+- **Created:** 2026-05-03T21:34:28.467+01:00
+
+## Team Assignments (2026-05-03)
+
+### Active Work
+
+**Issues:** #884, #885 (testing infrastructure)
+
+- **#884** (Review AutoData usage) — In Progress
+- **#885** (Review integration tests) — Can work in parallel
+
+**Label:** `squad:yen`
+
+## Learnings
+
+- The product spans frontend and backend, so testing will likely cross both layers.
+- Focus on recipe save and retrieval flows, plus regressions around data integrity.
+- Use the existing repo test patterns instead of inventing new frameworks.
+- Testing infrastructure cleanup (#884, #885) improves fixture maintainability and AppHost collection validation.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1,0 +1,55 @@
+# Squad Decisions
+
+## Active Decisions
+
+### Backlog Triage — 2026-05-03
+
+**Decision Owner:** Danny (Lead)  
+**Date:** 2026-05-03T21:56:25.759+01:00  
+**Status:** ✅ Implemented
+
+#### Summary
+
+Triaged 8 open GitHub issues in dgee2/Menu. Routed 7 issues into Squad workflow with explicit member assignments. Kept 1 epic untagged pending sub-issue completion.
+
+#### Routing Decisions
+
+| Issue | Title | Assigned To | Rationale |
+|-------|-------|-------------|-----------|
+| #1012 | Dependency Updates | squad:copilot | Good fit — well-scoped boilerplate task with clear acceptance criteria |
+| #977 | Prevent duplicate inserts (set-like) | squad:basher | Backend service/repository work; high-priority in epic sequence |
+| #978 | Prevent duplicate inserts (canonical) | squad:basher | Backend lookup-before-insert logic; clear scope with existing patterns |
+| #979 | Add uniqueness constraints | squad:basher | EF Core migrations and schema hardening; depends on #977/#978 |
+| #980 | Expose explicit duplicate conflicts | squad:basher | API contract work with endpoint-specific validation logic |
+| #884 | Review AutoData usage | squad:yen | Testing infrastructure cleanup; improves fixture maintainability |
+| #885 | Review integration tests | squad:yen | Testing infrastructure validation; checks AppHost collection usage |
+
+#### Epic Held in Backlog
+
+| Issue | Title | Reason |
+|-------|-------|--------|
+| #887 | Review update/insert API operations | Epic coordination work. Sub-issues assigned individually (977–980). Untagged until sub-issues complete. |
+
+#### Ordering (Basher Sequence)
+
+1. **#977** (set-like dedupe) — Required before #978 and #979
+2. **#978** (canonical dedupe) — Builds on #977 patterns
+3. **#979** (schema constraints) — Depends on #977/#978 completing
+4. **#980** (explicit conflicts) — Final step; API contracts
+
+Yen can work on #884 and #885 in parallel.
+
+#### Labels Created
+
+- `squad` — Issue is in Squad backlog
+- `squad:copilot` — Assigned to Copilot (coding agent)
+- `squad:basher` — Assigned to Basher (Backend Dev)
+- `squad:yen` — Assigned to Yen (Tester)
+
+---
+
+## Governance
+
+- All meaningful changes require team consensus
+- Document architectural decisions here
+- Keep history focused on work, decisions focused on direction

--- a/.squad/decisions/inbox/basher-issue-977.md
+++ b/.squad/decisions/inbox/basher-issue-977.md
@@ -1,0 +1,6 @@
+# Basher decision — issue #977
+
+- Date: 2026-05-03T21:56:25.759+01:00
+- Decision: Treat exact duplicate entries on set-like backend writes as idempotent in both service and repository layers.
+- Scope: `POST /api/ingredient`, `POST /api/recipe`, and `PUT /api/recipe/{recipeId}`.
+- Rationale: Normalizing duplicate-equivalent payload items before persistence keeps existing success responses unchanged and prevents duplicate insert attempts against composite-key child/link tables. Conflicting duplicates remain out of scope here and stay available for explicit validation work in issue #980.

--- a/.squad/skills/set-like-write-dedupe/SKILL.md
+++ b/.squad/skills/set-like-write-dedupe/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: "set-like-write-dedupe"
+description: "Normalize exact duplicates for set-like backend writes before child or junction table persistence"
+domain: "backend"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this pattern when a Menu backend request carries a set-like collection whose duplicates add no business meaning, but the persistence layer writes child rows or junction-table links that would otherwise attempt duplicate inserts.
+
+## Patterns
+- Normalize duplicate-equivalent request items in the service layer before calling repositories so the request becomes idempotent without changing the API contract.
+- Repeat the dedupe defensively in repository write paths before creating child/link entities; repository methods should stay safe even if a future caller skips the service.
+- For `RecipeIngredient` inputs, only collapse **exact** duplicates (`IngredientName`, `UnitName`, and `Amount` all match). Leave conflicting duplicates to explicit validation behavior.
+- For junction-table ID collections like `UnitIds`, deduplicate by the identifier value before materializing `IngredientUnitEntity` rows.
+
+## Examples
+```csharp
+var normalizedIngredient = new NewIngredient
+{
+    Name = newIngredient.Name,
+    UnitIds = [.. newIngredient.UnitIds.Distinct()],
+};
+
+var ingredients = [.. ViewModelMapper.Map(newRecipe.Ingredients).Distinct()];
+```
+
+## Anti-Patterns
+- Deduplicating only at the database boundary and leaving service calls free to send unstable duplicate payloads downstream.
+- Collapsing conflicting duplicates that should stay available for a later validation or conflict response.
+- Assuming composite primary keys are enough; they block persisted duplicates but do not stop duplicate insert attempts from request payloads.

--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -87,6 +87,19 @@ public class IngredientIntegrationTests : IClassFixture<ApiTestFixture>
         ingredients.Should().Contain(i => i.Id == createdId && i.Name == ingredientName);
     }
 
+    [Theory, AutoData]
+    public async Task Create_Ingredient_With_Duplicate_Units_Returns_Unique_Units([StringLength(50, MinimumLength = 1)] string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var (_, name, units) = await PostIngredientAsync(client, ingredientName, [1, 1, 4, 4]);
+
+        name.Should().Be(ingredientName);
+        units.Should().HaveCount(2);
+        units.Should().ContainSingle(u => u.Name == "Millilitres");
+        units.Should().ContainSingle(u => u.Name == "Grams");
+    }
+
     internal async Task<(int Id, string Name, List<IngredientUnit> Units)> PostIngredientAsync(
         HttpClient client, string name, List<int> unitIds)
     {

--- a/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
@@ -82,6 +82,7 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
         returnedIngredients[0].Amount.Should().Be(250.5m);
     }
 
+    [Theory, AutoData]
     public async Task Create_Recipe_With_Ingredients_Then_Get_Recipe_Returns_Ingredients(
         [StringLength(50, MinimumLength = 1)] string ingredientName,
         [StringLength(500, MinimumLength = 1)] string recipeName)
@@ -185,25 +186,13 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
             ]
         };
 
-        var putContent = new StringContent(JsonSerializer.Serialize(updatedRecipe, jsonOptions), Encoding.UTF8, "application/json");
-        using var putResponse = await client.PutAsync($"/api/recipe/{recipeId}", putContent);
-        await putResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+        var (_, returnedName, returnedIngredients) = await PutRecipeAsync(client, recipeId, updatedRecipe);
 
-        // GET the recipe and verify the update
-        using var getResponse = await client.GetAsync($"/api/recipe/{recipeId}");
-        await getResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        using var getStream = await getResponse.Content.ReadAsStreamAsync();
-        using var getDoc = await JsonDocument.ParseAsync(getStream);
-        var root = getDoc.RootElement;
-
-        root.GetProperty("name").GetString().Should().Be(updatedRecipeName);
-        var ingredients = JsonSerializer.Deserialize<List<RecipeIngredient>>(
-            root.GetProperty("ingredients").GetRawText(), jsonOptions)!;
-        ingredients.Should().HaveCount(1);
-        ingredients[0].Name.Should().Be(ingredientName2);
-        ingredients[0].Unit.Should().Be("Millilitres");
-        ingredients[0].Amount.Should().Be(200m);
+        returnedName.Should().Be(updatedRecipeName);
+        returnedIngredients.Should().HaveCount(1);
+        returnedIngredients[0].Name.Should().Be(ingredientName2);
+        returnedIngredients[0].Unit.Should().Be("Millilitres");
+        returnedIngredients[0].Amount.Should().Be(200m);
     }
 
     [Theory, AutoData]
@@ -237,24 +226,13 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
             ]
         };
 
-        var putContent = new StringContent(JsonSerializer.Serialize(updatedRecipe, jsonOptions), Encoding.UTF8, "application/json");
-        using var putResponse = await client.PutAsync($"/api/recipe/{recipeId}", putContent);
-        await putResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+        var (_, returnedName, returnedIngredients) = await PutRecipeAsync(client, recipeId, updatedRecipe);
 
-        using var getResponse = await client.GetAsync($"/api/recipe/{recipeId}");
-        await getResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        using var getStream = await getResponse.Content.ReadAsStreamAsync();
-        using var getDoc = await JsonDocument.ParseAsync(getStream);
-        var root = getDoc.RootElement;
-
-        root.GetProperty("name").GetString().Should().Be(updatedRecipeName);
-        var ingredients = JsonSerializer.Deserialize<List<RecipeIngredient>>(
-            root.GetProperty("ingredients").GetRawText(), jsonOptions)!;
-        ingredients.Should().HaveCount(1);
-        ingredients[0].Name.Should().Be(ingredientName);
-        ingredients[0].Unit.Should().Be("Grams");
-        ingredients[0].Amount.Should().Be(125m);
+        returnedName.Should().Be(updatedRecipeName);
+        returnedIngredients.Should().HaveCount(1);
+        returnedIngredients[0].Name.Should().Be(ingredientName);
+        returnedIngredients[0].Unit.Should().Be("Grams");
+        returnedIngredients[0].Amount.Should().Be(125m);
     }
 
     private async Task PostIngredientAsync(HttpClient client, string name, List<int> unitIds)
@@ -268,7 +246,7 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
     private async Task<(int Id, string Name, List<RecipeIngredient> Ingredients)> PostRecipeAsync(
         HttpClient client, NewRecipe recipe)
     {
-        var content = new StringContent(JsonSerializer.Serialize(recipe, jsonOptions), Encoding.UTF8, "application/json");
+        using var content = new StringContent(JsonSerializer.Serialize(recipe, jsonOptions), Encoding.UTF8, "application/json");
         using var response = await client.PostAsync("/api/recipe", content);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
@@ -283,6 +261,26 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
             root.GetProperty("ingredients").GetRawText(), jsonOptions) ?? [];
 
         return (id, name, ingredients);
+    }
+
+    private async Task<(int Id, string Name, List<RecipeIngredient> Ingredients)> PutRecipeAsync(
+        HttpClient client, int id, NewRecipe recipe)
+    {
+        using var content = new StringContent(JsonSerializer.Serialize(recipe, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PutAsync($"/api/recipe/{id}", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        var root = jsonDoc.RootElement;
+
+        var updatedId = root.GetProperty("id").GetInt32();
+        var name = root.GetProperty("name").GetString()!;
+        var ingredients = JsonSerializer.Deserialize<List<RecipeIngredient>>(
+            root.GetProperty("ingredients").GetRawText(), jsonOptions) ?? [];
+
+        return (updatedId, name, ingredients);
     }
 
     private class NewIngredient

--- a/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
@@ -55,6 +55,33 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
     }
 
     [Theory, AutoData]
+    public async Task Create_Recipe_With_Duplicate_Equivalent_Ingredients_Returns_Single_Link(
+        [StringLength(50, MinimumLength = 1)] string ingredientName,
+        [StringLength(500, MinimumLength = 1)] string recipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var newRecipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 250.5m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 250.5m },
+            ]
+        };
+
+        var (_, returnedName, returnedIngredients) = await PostRecipeAsync(client, newRecipe);
+
+        returnedName.Should().Be(recipeName);
+        returnedIngredients.Should().HaveCount(1);
+        returnedIngredients[0].Name.Should().Be(ingredientName);
+        returnedIngredients[0].Unit.Should().Be("Grams");
+        returnedIngredients[0].Amount.Should().Be(250.5m);
+    }
+
     public async Task Create_Recipe_With_Ingredients_Then_Get_Recipe_Returns_Ingredients(
         [StringLength(50, MinimumLength = 1)] string ingredientName,
         [StringLength(500, MinimumLength = 1)] string recipeName)
@@ -177,6 +204,57 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
         ingredients[0].Name.Should().Be(ingredientName2);
         ingredients[0].Unit.Should().Be("Millilitres");
         ingredients[0].Amount.Should().Be(200m);
+    }
+
+    [Theory, AutoData]
+    public async Task Update_Recipe_With_Duplicate_Equivalent_Existing_Ingredient_Remains_Single_Link(
+        [StringLength(50, MinimumLength = 1)] string ingredientName,
+        [StringLength(500, MinimumLength = 1)] string recipeName,
+        [StringLength(500, MinimumLength = 1)] string updatedRecipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var newRecipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m }
+            ]
+        };
+
+        var (recipeId, _, _) = await PostRecipeAsync(client, newRecipe);
+
+        var updatedRecipe = new NewRecipe
+        {
+            Name = updatedRecipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 125m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 125m },
+            ]
+        };
+
+        var putContent = new StringContent(JsonSerializer.Serialize(updatedRecipe, jsonOptions), Encoding.UTF8, "application/json");
+        using var putResponse = await client.PutAsync($"/api/recipe/{recipeId}", putContent);
+        await putResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var getResponse = await client.GetAsync($"/api/recipe/{recipeId}");
+        await getResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var getStream = await getResponse.Content.ReadAsStreamAsync();
+        using var getDoc = await JsonDocument.ParseAsync(getStream);
+        var root = getDoc.RootElement;
+
+        root.GetProperty("name").GetString().Should().Be(updatedRecipeName);
+        var ingredients = JsonSerializer.Deserialize<List<RecipeIngredient>>(
+            root.GetProperty("ingredients").GetRawText(), jsonOptions)!;
+        ingredients.Should().HaveCount(1);
+        ingredients[0].Name.Should().Be(ingredientName);
+        ingredients[0].Unit.Should().Be("Grams");
+        ingredients[0].Amount.Should().Be(125m);
     }
 
     private async Task PostIngredientAsync(HttpClient client, string name, List<int> unitIds)

--- a/backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs
@@ -1,0 +1,91 @@
+using AwesomeAssertions;
+using MenuDB;
+using MenuDB.Data;
+using MenuApi.Repositories;
+using MenuApi.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MenuApi.Tests.Repositories;
+
+public class RecipeRepositoryTests
+{
+    [Fact]
+    public async Task UpsertRecipeIngredientsAsync_Deduplicates_Exact_Duplicate_New_Links()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedRecipeIngredientGraphAsync(db, cancellationToken);
+        var sut = new RecipeRepository(db);
+
+        await sut.UpsertRecipeIngredientsAsync(
+            RecipeId.From(1),
+            [
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(100m), IngredientUnitName.From("Grams")),
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(100m), IngredientUnitName.From("Grams")),
+            ]);
+
+        var rows = await db.RecipeIngredients
+            .Where(ri => ri.RecipeId == 1)
+            .ToListAsync(cancellationToken);
+
+        rows.Should().HaveCount(1);
+        rows[0].Amount.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task UpsertRecipeIngredientsAsync_Does_Not_ReAdd_Existing_Links_On_Update()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedRecipeIngredientGraphAsync(db, cancellationToken);
+        db.RecipeIngredients.Add(new RecipeIngredientEntity
+        {
+            RecipeId = 1,
+            IngredientId = 10,
+            UnitId = 4,
+            Amount = 50m,
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var sut = new RecipeRepository(db);
+
+        await sut.UpsertRecipeIngredientsAsync(
+            RecipeId.From(1),
+            [
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(75m), IngredientUnitName.From("Grams")),
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(75m), IngredientUnitName.From("Grams")),
+            ]);
+
+        var rows = await db.RecipeIngredients
+            .Where(ri => ri.RecipeId == 1)
+            .ToListAsync(cancellationToken);
+
+        rows.Should().HaveCount(1);
+        rows[0].Amount.Should().Be(75m);
+    }
+
+    private static MenuDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+
+    private static async Task SeedRecipeIngredientGraphAsync(MenuDbContext db, CancellationToken cancellationToken)
+    {
+        var unitType = new UnitTypeEntity { Id = 1, Name = "Weight" };
+        var unit = new UnitEntity { Id = 4, Name = "Grams", UnitTypeId = unitType.Id, UnitType = unitType };
+        var ingredient = new IngredientEntity { Id = 10, Name = "Sugar" };
+        var recipe = new RecipeEntity { Id = 1, Name = "Cake" };
+
+        db.UnitTypes.Add(unitType);
+        db.Units.Add(unit);
+        db.Ingredients.Add(ingredient);
+        db.Recipes.Add(recipe);
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
@@ -1,0 +1,51 @@
+using AwesomeAssertions;
+using FakeItEasy;
+using MenuApi.Repositories;
+using MenuApi.Services;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Xunit;
+
+namespace MenuApi.Tests.Services;
+
+public class IngredientServiceTests
+{
+    [Fact]
+    public async Task CreateIngredientAsync_Deduplicates_UnitIds_Before_Repository_Call()
+    {
+        var unitRepository = A.Fake<IUnitRepository>();
+        var ingredientRepository = A.Fake<IIngredientRepository>();
+        var expected = new Ingredient
+        {
+            Id = IngredientId.From(1),
+            Name = IngredientName.From("Sugar"),
+            Units = [],
+        };
+
+        A.CallTo(() => ingredientRepository.CreateIngredientAsync(
+                A<NewIngredient>.That.Matches(i =>
+                    i.Name == IngredientName.From("Sugar") &&
+                    i.UnitIds.Count == 2 &&
+                    i.UnitIds.Contains(1) &&
+                    i.UnitIds.Contains(4))))
+            .Returns(expected);
+
+        var sut = new IngredientService(unitRepository, ingredientRepository);
+        var newIngredient = new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [1, 1, 4, 4],
+        };
+
+        var result = await sut.CreateIngredientAsync(newIngredient);
+
+        result.Should().Be(expected);
+        A.CallTo(() => ingredientRepository.CreateIngredientAsync(
+                A<NewIngredient>.That.Matches(i =>
+                    i.Name == IngredientName.From("Sugar") &&
+                    i.UnitIds.Count == 2 &&
+                    i.UnitIds.Contains(1) &&
+                    i.UnitIds.Contains(4))))
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
@@ -101,6 +101,37 @@ public class RecipeServiceTests
         A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(recipe.Id, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustHaveHappenedOnceExactly();
     }
 
+    [Fact]
+    public async Task CreateRecipeAsync_Deduplicates_Exact_Duplicate_Ingredients_Before_Upsert()
+    {
+        var recipeId = RecipeId.From(1);
+        var recipeName = RecipeName.From("Cake");
+        var duplicateIngredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m),
+        };
+
+        A.CallTo(() => recipeRepository.CreateRecipeAsync(recipeName)).Returns(recipeId);
+
+        await sut.CreateRecipeAsync(new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [duplicateIngredient, duplicateIngredient],
+        });
+
+        A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(
+                recipeId,
+                A<IEnumerable<DBModel.RecipeIngredient>>.That.Matches(ingredients =>
+                    ingredients.Count() == 1 &&
+                    ingredients.Single() == new DBModel.RecipeIngredient(
+                        IngredientName.From("Sugar"),
+                        IngredientAmount.From(100m),
+                        IngredientUnitName.From("Grams")))))
+            .MustHaveHappenedOnceExactly();
+    }
+
     [Theory, CustomAutoData]
     public async Task UpdateRecipeSuccess(RecipeId recipeId, RecipeName recipeName, IEnumerable<DBModel.RecipeIngredient> ingredients)
     {
@@ -119,6 +150,35 @@ public class RecipeServiceTests
 
         A.CallTo(() => recipeRepository.UpdateRecipeAsync(recipeId, recipeName)).MustHaveHappenedOnceExactly();
         A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(recipeId, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UpdateRecipeAsync_Deduplicates_Exact_Duplicate_Ingredients_Before_Upsert()
+    {
+        var recipeId = RecipeId.From(1);
+        var recipeName = RecipeName.From("Cake");
+        var duplicateIngredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m),
+        };
+
+        await sut.UpdateRecipeAsync(recipeId, new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [duplicateIngredient, duplicateIngredient],
+        });
+
+        A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(
+                recipeId,
+                A<IEnumerable<DBModel.RecipeIngredient>>.That.Matches(ingredients =>
+                    ingredients.Count() == 1 &&
+                    ingredients.Single() == new DBModel.RecipeIngredient(
+                        IngredientName.From("Sugar"),
+                        IngredientAmount.From(100m),
+                        IngredientUnitName.From("Grams")))))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Theory, CustomAutoData]

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -39,10 +39,12 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
     {
         ArgumentNullException.ThrowIfNull(newIngredient);
 
+        var unitIds = newIngredient.UnitIds.Distinct().ToList();
+
         var entity = new IngredientEntity
         {
             Name = newIngredient.Name.Value,
-            IngredientUnits = newIngredient.UnitIds
+            IngredientUnits = unitIds
                 .Select(unitId => new IngredientUnitEntity { UnitId = unitId })
                 .ToList(),
         };

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -55,7 +55,7 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
     {
         ArgumentNullException.ThrowIfNull(recipeIngredients);
 
-        var incoming = recipeIngredients.ToList();
+        var incoming = recipeIngredients.Distinct().ToList();
         var incomingKeys = incoming
             .Select(i => new { IngredientName = i.IngredientName.Value, UnitName = i.UnitName.Value })
             .ToHashSet();

--- a/backend/MenuApi/Services/IngredientService.cs
+++ b/backend/MenuApi/Services/IngredientService.cs
@@ -14,7 +14,15 @@ public class IngredientService(IUnitRepository unitRepository, IIngredientReposi
 
     public async Task<Ingredient> CreateIngredientAsync(NewIngredient newIngredient)
     {
-        return await ingredientRepository.CreateIngredientAsync(newIngredient).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(newIngredient);
+
+        var normalizedIngredient = new NewIngredient
+        {
+            Name = newIngredient.Name,
+            UnitIds = [.. newIngredient.UnitIds.Distinct()],
+        };
+
+        return await ingredientRepository.CreateIngredientAsync(normalizedIngredient).ConfigureAwait(false);
     }
 }
 

--- a/backend/MenuApi/Services/RecipeService.cs
+++ b/backend/MenuApi/Services/RecipeService.cs
@@ -1,4 +1,4 @@
-﻿using MenuDB;
+using MenuDB;
 using MenuApi.MappingProfiles;
 using MenuApi.Repositories;
 using MenuApi.ValueObjects;
@@ -39,7 +39,7 @@ public class RecipeService(IRecipeRepository recipeRepository, MenuDbContext db)
     {
         ArgumentNullException.ThrowIfNull(newRecipe);
 
-        var ingredients = ViewModelMapper.Map(newRecipe.Ingredients);
+        var ingredients = NormalizeRecipeIngredients(newRecipe.Ingredients);
 
         var strategy = db.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
@@ -56,7 +56,7 @@ public class RecipeService(IRecipeRepository recipeRepository, MenuDbContext db)
     {
         ArgumentNullException.ThrowIfNull(newRecipe);
 
-        var ingredients = ViewModelMapper.Map(newRecipe.Ingredients);
+        var ingredients = NormalizeRecipeIngredients(newRecipe.Ingredients);
 
         var strategy = db.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
@@ -66,5 +66,11 @@ public class RecipeService(IRecipeRepository recipeRepository, MenuDbContext db)
             await recipeRepository.UpsertRecipeIngredientsAsync(recipeId, ingredients).ConfigureAwait(false);
             await tran.CommitAsync().ConfigureAwait(false);
         }).ConfigureAwait(false);
+    }
+
+    private static IReadOnlyList<DBModel.RecipeIngredient> NormalizeRecipeIngredients(IEnumerable<ViewModel.RecipeIngredient> recipeIngredients)
+    {
+        ArgumentNullException.ThrowIfNull(recipeIngredients);
+        return [.. ViewModelMapper.Map(recipeIngredients).Distinct()];
     }
 }


### PR DESCRIPTION
## Summary
- dedupe duplicate-equivalent unit-id and recipe-ingredient payload items before persistence
- keep repository write paths defensive so exact duplicate child/link rows are not re-added on create or update
- add unit and integration coverage for duplicate-equivalent ingredient and recipe requests

## Testing
- dotnet test --project .\backend\MenuApi.Tests\MenuApi.Tests.csproj
- dotnet test --project .\backend\MenuApi.Integration.Tests\MenuApi.Integration.Tests.csproj

Closes #977