### PR TITLE
Review integration tests to use a single application instance

### DIFF
--- a/backend/MenuApi.Integration.Tests/Factory/ApiTestFixture.cs
+++ b/backend/MenuApi.Integration.Tests/Factory/ApiTestFixture.cs
@@ -1,9 +1,10 @@
-﻿using Aspire.Hosting;
+using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
+using System.Threading;
 using Xunit;
 
 
@@ -11,23 +12,84 @@ namespace MenuApi.Integration.Tests.Factory;
 
 public class ApiTestFixture : IAsyncLifetime
 {
+    private static readonly SemaphoreSlim SharedStateLock = new(1, 1);
+    private static DistributedApplication sharedApp;
+    private static AuthenticationHeaderValue sharedAuthHeader;
+    private static int activeFixtureCount;
+    private static bool applicationCreated;
+
     public DistributedApplication app { get; private set; }
-    private IDistributedApplicationTestingBuilder appHost;
-    private AuthenticationHeaderValue cachedAuthHeader;
 
     public async Task<HttpClient> GetHttpClient()
     {
         var httpClient = app.CreateHttpClient("apiservice");
 
-        cachedAuthHeader ??= await new ApiAuthentication().GetAuthenticationHeaderValue();
+        sharedAuthHeader ??= await new ApiAuthentication().GetAuthenticationHeaderValue();
 
-        httpClient.DefaultRequestHeaders.Authorization = cachedAuthHeader;
+        httpClient.DefaultRequestHeaders.Authorization = sharedAuthHeader;
         return httpClient;
     }
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
-        appHost = await DistributedApplicationTestingBuilder
+        await SharedStateLock.WaitAsync();
+        try
+        {
+            if (sharedApp is null)
+            {
+                if (applicationCreated)
+                {
+                    throw new InvalidOperationException(
+                        "ApiTestFixture should only create the distributed application once per test run.");
+                }
+
+                sharedApp = await CreateSharedAppAsync();
+                applicationCreated = true;
+            }
+
+            activeFixtureCount++;
+            app = sharedApp;
+        }
+        finally
+        {
+            SharedStateLock.Release();
+        }
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        DistributedApplication appToDispose = null;
+
+        await SharedStateLock.WaitAsync();
+        try
+        {
+            if (activeFixtureCount > 0)
+            {
+                activeFixtureCount--;
+            }
+
+            if (activeFixtureCount == 0 && sharedApp is not null)
+            {
+                appToDispose = sharedApp;
+                sharedApp = null;
+                sharedAuthHeader = null;
+            }
+        }
+        finally
+        {
+            SharedStateLock.Release();
+        }
+
+        if (appToDispose is not null)
+        {
+            await appToDispose.StopAsync();
+            await appToDispose.DisposeAsync();
+        }
+    }
+
+    private static async Task<DistributedApplication> CreateSharedAppAsync()
+    {
+        var appHost = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.Menu_AppHost>();
 
         appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
@@ -43,7 +105,7 @@ public class ApiTestFixture : IAsyncLifetime
 
         appHost.WithContainersLifetime(ContainerLifetime.Session);
 
-        app = await appHost.BuildAsync();
+        var app = await appHost.BuildAsync();
 
         await app.StartAsync();
 
@@ -60,11 +122,8 @@ public class ApiTestFixture : IAsyncLifetime
             KnownResourceStates.Running
             )
             .WaitAsync(TimeSpan.FromSeconds(30));
-    }
-    async ValueTask IAsyncDisposable.DisposeAsync()
-    {
-        await app.StopAsync();
-        await app.DisposeAsync();
+
+        return app;
     }
 }
 

--- a/backend/MenuApi.Integration.Tests/Factory/ApiTestFixture.cs
+++ b/backend/MenuApi.Integration.Tests/Factory/ApiTestFixture.cs
@@ -4,7 +4,6 @@ using Aspire.Hosting.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
-using System.Threading;
 using Xunit;
 
 
@@ -12,84 +11,23 @@ namespace MenuApi.Integration.Tests.Factory;
 
 public class ApiTestFixture : IAsyncLifetime
 {
-    private static readonly SemaphoreSlim SharedStateLock = new(1, 1);
-    private static DistributedApplication sharedApp;
-    private static AuthenticationHeaderValue sharedAuthHeader;
-    private static int activeFixtureCount;
-    private static bool applicationCreated;
-
     public DistributedApplication app { get; private set; }
+    private IDistributedApplicationTestingBuilder appHost;
+    private AuthenticationHeaderValue cachedAuthHeader;
 
     public async Task<HttpClient> GetHttpClient()
     {
         var httpClient = app.CreateHttpClient("apiservice");
 
-        sharedAuthHeader ??= await new ApiAuthentication().GetAuthenticationHeaderValue();
+        cachedAuthHeader ??= await new ApiAuthentication().GetAuthenticationHeaderValue();
 
-        httpClient.DefaultRequestHeaders.Authorization = sharedAuthHeader;
+        httpClient.DefaultRequestHeaders.Authorization = cachedAuthHeader;
         return httpClient;
     }
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
-        await SharedStateLock.WaitAsync();
-        try
-        {
-            if (sharedApp is null)
-            {
-                if (applicationCreated)
-                {
-                    throw new InvalidOperationException(
-                        "ApiTestFixture should only create the distributed application once per test run.");
-                }
-
-                sharedApp = await CreateSharedAppAsync();
-                applicationCreated = true;
-            }
-
-            activeFixtureCount++;
-            app = sharedApp;
-        }
-        finally
-        {
-            SharedStateLock.Release();
-        }
-    }
-
-    async ValueTask IAsyncDisposable.DisposeAsync()
-    {
-        DistributedApplication appToDispose = null;
-
-        await SharedStateLock.WaitAsync();
-        try
-        {
-            if (activeFixtureCount > 0)
-            {
-                activeFixtureCount--;
-            }
-
-            if (activeFixtureCount == 0 && sharedApp is not null)
-            {
-                appToDispose = sharedApp;
-                sharedApp = null;
-                sharedAuthHeader = null;
-            }
-        }
-        finally
-        {
-            SharedStateLock.Release();
-        }
-
-        if (appToDispose is not null)
-        {
-            await appToDispose.StopAsync();
-            await appToDispose.DisposeAsync();
-        }
-    }
-
-    private static async Task<DistributedApplication> CreateSharedAppAsync()
-    {
-        var appHost = await DistributedApplicationTestingBuilder
+        appHost = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.Menu_AppHost>();
 
         appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
@@ -105,7 +43,7 @@ public class ApiTestFixture : IAsyncLifetime
 
         appHost.WithContainersLifetime(ContainerLifetime.Session);
 
-        var app = await appHost.BuildAsync();
+        app = await appHost.BuildAsync();
 
         await app.StartAsync();
 
@@ -122,8 +60,11 @@ public class ApiTestFixture : IAsyncLifetime
             KnownResourceStates.Running
             )
             .WaitAsync(TimeSpan.FromSeconds(30));
-
-        return app;
+    }
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await app.StopAsync();
+        await app.DisposeAsync();
     }
 }
 

--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace MenuApi.Integration.Tests;
 
 [Collection("API Host Collection")]
-public class IngredientIntegrationTests : IClassFixture<ApiTestFixture>
+public class IngredientIntegrationTests
 {
     private readonly JsonSerializerOptions jsonOptions;
     private readonly ApiTestFixture fixture;

--- a/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace MenuApi.Integration.Tests;
 
 [Collection("API Host Collection")]
-public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
+public class RecipeIntegrationTests
 {
     private const string Grams = "Grams";
 

--- a/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace MenuApi.Integration.Tests;
 
 [Collection("API Host Collection")]
-public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixture>
+public class RecipeWithIngredientsIntegrationTests
 {
     private readonly JsonSerializerOptions jsonOptions;
     private readonly ApiTestFixture fixture;

--- a/backend/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/ValidationIntegrationTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace MenuApi.Integration.Tests;
 
 [Collection("API Host Collection")]
-public class ValidationIntegrationTests : IClassFixture<ApiTestFixture>
+public class ValidationIntegrationTests
 {
     private const string ApplicationJson = "application/json";
     private const string ApiRecipeRoute = "/api/recipe";


### PR DESCRIPTION
## Summary
- remove redundant `IClassFixture<ApiTestFixture>` usage from the integration test classes in the shared API host collection
- keep `ApiTestFixture` instance-scoped so the xUnit collection fixture lifecycle provides the single shared Aspire app without static state
- retain cached auth header reuse on the shared collection fixture

## Testing
- dotnet test --project .\backend\MenuApi.Tests\MenuApi.Tests.csproj --output Detailed --no-progress
- dotnet test --project .\backend\MenuApi.Integration.Tests\MenuApi.Integration.Tests.csproj --output Detailed --no-progress

Closes #885