### PR TITLE
Add missing uniqueness constraints and migration preparation

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -1,0 +1,47 @@
+# Project Context
+
+- **Owner:** Daniel Gee
+- **Project:** Menu
+- **Stack:** Vue 3, Quasar, TypeScript, C#/.NET, EF Core, Aspire
+- **Description:** Recipe management app for customers to save and access recipes easily.
+- **Created:** 2026-05-03T21:56:25.759+01:00
+
+## Team Assignments (2026-05-03T21:56:25.759+01:00)
+
+### Active Work
+
+**Issues:** #977, #978, #979, #980 (duplicate prevention epic)
+
+- **#977** (Prevent duplicate inserts — set-like) — PR opened / clean handoff
+- **#978** (Prevent duplicate inserts — canonical) — Implemented
+- **#979** (Add uniqueness constraints) — Depends on #977/#978
+- **#980** (Expose explicit duplicate conflicts) — Final step
+
+**Label:** `squad:basher`
+
+## Learnings
+
+- Backend stack is C#/.NET with Aspire orchestration.
+- Backend code lives under `backend/`.
+- Recipe persistence and API behavior are core product responsibilities.
+- Duplicate handling work is sequenced: service/repo logic → schema constraints → API contract.
+- Exact duplicate handling for set-like writes now normalizes request payloads in `backend/MenuApi/Services/IngredientService.cs` and `backend/MenuApi/Services/RecipeService.cs` before repository calls.
+- Repository write paths also stay defensive: `backend/MenuApi/Repositories/IngredientRepository.cs` deduplicates `UnitIds`, and `backend/MenuApi/Repositories/RecipeRepository.cs` deduplicates exact `RecipeIngredient` records before upsert.
+- Regression coverage for duplicate-equivalent write requests lives in `backend/MenuApi.Tests/Services/IngredientServiceTests.cs`, `backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs`, `backend/MenuApi.Tests/Services/RecipeServiceTests.cs`, `backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs`, and `backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs`.
+- Canonical ingredient writes now normalize `UnitIds` in `backend/MenuApi/Services/IngredientService.cs` before repository comparison so equivalent payloads match existing rows regardless of order or repetition.
+- `backend/MenuApi/Repositories/IngredientRepository.cs` now performs lookup-before-insert by ingredient name, reuses equivalent canonical rows, and blocks differing unit-set redefinitions before a duplicate row is written.
+- Canonical-row reuse coverage lives in `backend/MenuApi.Tests/Services/IngredientServiceTests.cs`, `backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs`, and `backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs`.
+
+### Issue #977: Duplicate Prevention (2026-05-03T21:56:25.759+01:00)
+
+- **Status:** ✅ PR opened / clean handoff
+- **Decision:** Treat exact duplicate entries on set-like writes as idempotent in both service and repository layers
+- **Scope:** `POST /api/ingredient`, `POST /api/recipe`, and `PUT /api/recipe/{recipeId}`
+- **Rationale:** Normalization keeps existing success responses unchanged; prevents duplicate inserts against composite-key child tables
+
+### Issue #978: Canonical Ingredient Reuse (2026-05-03T21:56:25.759+01:00)
+
+- **Status:** ✅ Implemented
+- **Decision:** Canonical ingredient creation now reuses an existing same-name row only when the normalized unit-id set is equivalent; otherwise the write is rejected before insert.
+- **Scope:** `POST /api/ingredient`
+- **Rationale:** Ingredient names are later resolved by name in recipe writes, so allowing multiple persisted definitions for the same canonical ingredient would keep lookups ambiguous and block safe uniqueness constraints in #979.

--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -31,6 +31,9 @@
 - Canonical ingredient writes now normalize `UnitIds` in `backend/MenuApi/Services/IngredientService.cs` before repository comparison so equivalent payloads match existing rows regardless of order or repetition.
 - `backend/MenuApi/Repositories/IngredientRepository.cs` now performs lookup-before-insert by ingredient name, reuses equivalent canonical rows, and blocks differing unit-set redefinitions before a duplicate row is written.
 - Canonical-row reuse coverage lives in `backend/MenuApi.Tests/Services/IngredientServiceTests.cs`, `backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs`, and `backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs`.
+- Confirmed business-unique columns are currently `backend/MenuDB\Data\IngredientEntity.Name` and `backend/MenuDB\Data\RecipeEntity.Name`; `backend/MenuDB\MenuDbContext.cs` now enforces both with unique indexes.
+- Migration `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs` now pre-checks for duplicate `Ingredient.Name` and `Recipe.Name` rows before creating unique indexes so deployments fail with actionable remediation guidance instead of opaque SQL index errors.
+- Schema hardening verification now includes model-metadata tests in `backend/MenuApi.Tests\Database\MenuDbContextTests.cs` plus an idempotent migration script generation check (`dotnet ef migrations script --idempotent --project MenuDB --startup-project MenuApi`).
 
 ### Issue #977: Duplicate Prevention (2026-05-03T21:56:25.759+01:00)
 
@@ -41,7 +44,14 @@
 
 ### Issue #978: Canonical Ingredient Reuse (2026-05-03T21:56:25.759+01:00)
 
-- **Status:** ✅ Implemented
+- **Status:** ✅ PR opened / clean handoff
 - **Decision:** Canonical ingredient creation now reuses an existing same-name row only when the normalized unit-id set is equivalent; otherwise the write is rejected before insert.
 - **Scope:** `POST /api/ingredient`
 - **Rationale:** Ingredient names are later resolved by name in recipe writes, so allowing multiple persisted definitions for the same canonical ingredient would keep lookups ambiguous and block safe uniqueness constraints in #979.
+
+### Issue #979: Schema Hardening (2026-05-03T21:56:25.759+01:00)
+
+- **Status:** ✅ Implemented
+- **Decision:** Add database-enforced unique indexes for `Ingredient.Name` and `Recipe.Name`, and make the migration fail early with explicit remediation guidance if duplicate data already exists.
+- **Scope:** `backend/MenuDB\MenuDbContext.cs`, `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs`, and `docs/specs/backend-write-duplicate-risk-audit.md`
+- **Rationale:** Application-layer normalization now covers canonical ingredients, and the remaining business-unique names need schema enforcement before duplicate handling can be completed cleanly in #980.

--- a/.squad/decisions/inbox/basher-issue-978.md
+++ b/.squad/decisions/inbox/basher-issue-978.md
@@ -1,0 +1,6 @@
+# Basher decision — issue #978
+
+- Date: 2026-05-03T21:56:25.759+01:00
+- Decision: For canonical ingredient rows, normalize incoming `UnitIds`, reuse an existing same-name ingredient when the effective unit set matches, and block mismatched redefinitions before insert.
+- Scope: `POST /api/ingredient`
+- Rationale: Ingredient rows behave as reference data for recipe writes, so the backend must perform lookup-before-insert to keep name-based resolution unambiguous and to prepare the schema for uniqueness constraints in #979.

--- a/.squad/decisions/inbox/basher-issue-979.md
+++ b/.squad/decisions/inbox/basher-issue-979.md
@@ -1,0 +1,6 @@
+# Basher decision — issue #979
+
+- Date: 2026-05-03T21:56:25.759+01:00
+- Decision: Enforce uniqueness at the database level for `Ingredient.Name` and `Recipe.Name`, and gate the migration with duplicate-data checks that fail fast with remediation instructions.
+- Scope: `backend/MenuDB\MenuDbContext.cs`, `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs`, and `docs/specs/backend-write-duplicate-risk-audit.md`
+- Rationale: These are the confirmed business-unique names in the duplicate-prevention epic. Failing the migration before index creation keeps deployment risk explicit and prepares #980 to translate remaining duplicate-name writes into deliberate API responses.

--- a/.squad/skills/canonical-reference-row-reuse/SKILL.md
+++ b/.squad/skills/canonical-reference-row-reuse/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: "canonical-reference-row-reuse"
+description: "Reuse existing canonical ingredient rows by normalized definition before inserting new reference data"
+domain: "backend"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this pattern when a Menu backend write creates reference data that should have one canonical stored definition, and future writes resolve that data by a business key rather than by surrogate ID.
+
+## Patterns
+- Normalize request collections before comparison so equivalent payloads match regardless of ordering or repeated IDs.
+- Query by the canonical business key (`Ingredient.Name`) before insert and compare the effective definition (`UnitIds` set) against existing rows.
+- Reuse the existing row when the normalized definitions match; return the existing API shape so the behavior stays client-transparent for equivalent requests.
+- Reject mismatched redefinitions before insert so later schema constraints can rely on a single persisted definition per canonical key.
+
+## Examples
+```csharp
+var normalizedUnitIds = newIngredient.UnitIds.Distinct().ToList();
+var existingEquivalentIngredient = existingIngredients
+    .FirstOrDefault(i => i.IngredientUnits.Select(iu => iu.UnitId).ToHashSet().SetEquals(normalizedUnitIds));
+
+if (existingEquivalentIngredient is not null)
+{
+    return MapIngredient(existingEquivalentIngredient);
+}
+```
+
+## Anti-Patterns
+- Comparing raw request lists without deduplicating or ignoring order first.
+- Inserting a second reference row with the same canonical name and hoping later code will "pick the right one".
+- Reusing an existing canonical row when the incoming definition differs in a business-significant way.

--- a/.squad/skills/unique-index-migration-guards/SKILL.md
+++ b/.squad/skills/unique-index-migration-guards/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: "unique-index-migration-guards"
+description: "Add duplicate-data guard SQL before creating business-unique indexes in Menu migrations"
+domain: "backend"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this pattern when Menu adds a new unique index for a business key and existing shared environments may already contain duplicate rows that would make the migration fail at deploy time.
+
+## Patterns
+- Add the unique index in `MenuDbContext` so the EF model, snapshot, and generated migration stay aligned.
+- Keep the migration focused on the unique-index change, but prepend explicit SQL duplicate checks for each constrained table before `CreateIndex(... unique: true)`.
+- Make the guard SQL throw a specific remediation message naming the affected business key so deployment failures explain exactly what data must be cleaned up.
+- Document the pre-deployment duplicate audit queries and cleanup steps in existing backend docs when the migration affects shared data.
+
+## Examples
+```csharp
+migrationBuilder.Sql(
+    """
+    IF EXISTS (
+        SELECT [Name]
+        FROM [Recipe]
+        GROUP BY [Name]
+        HAVING COUNT(*) > 1
+    )
+    BEGIN
+        THROW 50000, 'Cannot apply AddBusinessUniqueIndexes while duplicate Recipe.Name rows exist. Remediate duplicate recipe names before retrying the migration.', 1;
+    END;
+    """);
+```
+
+## Anti-Patterns
+- Adding a unique index without checking whether existing shared data can satisfy it.
+- Relying on raw SQL Server error 1505 output as the only remediation signal for deployments.
+- Documenting cleanup steps only in PR text instead of in durable repo docs tied to the migration.

--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -85,6 +85,29 @@ public class IngredientIntegrationTests : IClassFixture<ApiTestFixture>
         ingredients.Should().Contain(i => i.Id == createdId && i.Name == ingredientName);
     }
 
+    [Theory, ShortStringAutoData]
+    public async Task Create_Ingredient_Reuses_Equivalent_Existing_Canonical_Row(string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var (firstId, _, _) = await PostIngredientAsync(client, ingredientName, [1, 4]);
+        var (secondId, secondName, secondUnits) = await PostIngredientAsync(client, ingredientName, [4, 1, 4]);
+
+        secondId.Should().Be(firstId);
+        secondName.Should().Be(ingredientName);
+        secondUnits.Should().HaveCount(2);
+        secondUnits.Should().ContainSingle(u => u.Name == "Millilitres");
+        secondUnits.Should().ContainSingle(u => u.Name == "Grams");
+
+        using var response = await client.GetAsync("/api/ingredient");
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        var data = await response.Content.ReadAsStringAsync();
+        var ingredients = JsonSerializer.Deserialize<List<Ingredient>>(data, jsonOptions);
+        ingredients.Should().NotBeNull();
+        ingredients.Where(i => i.Name == ingredientName).Should().ContainSingle(i => i.Id == firstId);
+    }
+
     internal async Task<(int Id, string Name, List<IngredientUnit> Units)> PostIngredientAsync(
         HttpClient client, string name, List<int> unitIds)
     {

--- a/backend/MenuApi.Tests/Database/MenuDbContextTests.cs
+++ b/backend/MenuApi.Tests/Database/MenuDbContextTests.cs
@@ -1,0 +1,43 @@
+using AwesomeAssertions;
+using MenuDB;
+using MenuDB.Data;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MenuApi.Tests.Database;
+
+public class MenuDbContextTests
+{
+    [Fact]
+    public void Ingredient_Name_Has_Unique_Index()
+    {
+        using var db = CreateDbContext();
+
+        var ingredientEntity = db.Model.FindEntityType(typeof(IngredientEntity));
+        var ingredientNameIndex = ingredientEntity!.GetIndexes()
+            .Single(index => index.Properties.Select(property => property.Name).SequenceEqual(["Name"]));
+
+        ingredientNameIndex.IsUnique.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Recipe_Name_Has_Unique_Index()
+    {
+        using var db = CreateDbContext();
+
+        var recipeEntity = db.Model.FindEntityType(typeof(RecipeEntity));
+        var recipeNameIndex = recipeEntity!.GetIndexes()
+            .Single(index => index.Properties.Select(property => property.Name).SequenceEqual(["Name"]));
+
+        recipeNameIndex.IsUnique.Should().BeTrue();
+    }
+
+    private static MenuDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+}

--- a/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
@@ -1,0 +1,99 @@
+using AwesomeAssertions;
+using MenuDB;
+using MenuDB.Data;
+using MenuApi.Exceptions;
+using MenuApi.Repositories;
+using MenuApi.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MenuApi.Tests.Repositories;
+
+public class IngredientRepositoryTests
+{
+    [Fact]
+    public async Task CreateIngredientAsync_Reuses_Equivalent_Canonical_Ingredient()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedUnitGraphAsync(db, cancellationToken);
+        db.Ingredients.Add(new IngredientEntity
+        {
+            Id = 10,
+            Name = "Sugar",
+            IngredientUnits =
+            [
+                new IngredientUnitEntity { UnitId = 1 },
+                new IngredientUnitEntity { UnitId = 4 },
+            ],
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var sut = new IngredientRepository(db);
+
+        var result = await sut.CreateIngredientAsync(new MenuApi.ViewModel.NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [4, 1, 4],
+        });
+
+        result.Id.Should().Be(IngredientId.From(10));
+        result.Name.Should().Be(IngredientName.From("Sugar"));
+        result.Units.Should().HaveCount(2);
+        result.Units.Should().ContainSingle(u => u.Name == IngredientUnitName.From("Millilitres"));
+        result.Units.Should().ContainSingle(u => u.Name == IngredientUnitName.From("Grams"));
+        (await db.Ingredients.CountAsync(i => i.Name == "Sugar", cancellationToken)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateIngredientAsync_Rejects_Canonical_Redefinition()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedUnitGraphAsync(db, cancellationToken);
+        db.Ingredients.Add(new IngredientEntity
+        {
+            Id = 10,
+            Name = "Sugar",
+            IngredientUnits =
+            [
+                new IngredientUnitEntity { UnitId = 1 },
+            ],
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var sut = new IngredientRepository(db);
+
+        var act = async () => await sut.CreateIngredientAsync(new MenuApi.ViewModel.NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [1, 4],
+        });
+
+        await act.Should().ThrowAsync<BusinessValidationException>()
+            .WithMessage("Ingredient 'Sugar' already exists with a different unit set.");
+        (await db.Ingredients.CountAsync(i => i.Name == "Sugar", cancellationToken)).Should().Be(1);
+    }
+
+    private static MenuDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+
+    private static async Task SeedUnitGraphAsync(MenuDbContext db, CancellationToken cancellationToken)
+    {
+        var volumeType = new UnitTypeEntity { Id = 1, Name = "Volume" };
+        var weightType = new UnitTypeEntity { Id = 3, Name = "Weight" };
+
+        db.UnitTypes.AddRange(volumeType, weightType);
+        db.Units.AddRange(
+            new UnitEntity { Id = 1, Name = "Millilitres", Abbreviation = "ml", UnitTypeId = 1, UnitType = volumeType },
+            new UnitEntity { Id = 4, Name = "Grams", Abbreviation = "g", UnitTypeId = 3, UnitType = weightType });
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
@@ -1,0 +1,50 @@
+using AwesomeAssertions;
+using FakeItEasy;
+using MenuApi.Repositories;
+using MenuApi.Services;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Xunit;
+
+namespace MenuApi.Tests.Services;
+
+public class IngredientServiceTests
+{
+    [Fact]
+    public async Task CreateIngredientAsync_Deduplicates_UnitIds_Before_Repository_Call()
+    {
+        var unitRepository = A.Fake<IUnitRepository>();
+        var ingredientRepository = A.Fake<IIngredientRepository>();
+        var expected = new Ingredient
+        {
+            Id = IngredientId.From(1),
+            Name = IngredientName.From("Sugar"),
+            Units = [],
+        };
+
+        A.CallTo(() => ingredientRepository.CreateIngredientAsync(
+                A<NewIngredient>.That.Matches(i =>
+                    i.Name == IngredientName.From("Sugar") &&
+                    i.UnitIds.Count == 2 &&
+                    i.UnitIds.Contains(1) &&
+                    i.UnitIds.Contains(4))))
+            .Returns(expected);
+
+        var sut = new IngredientService(unitRepository, ingredientRepository);
+
+        var result = await sut.CreateIngredientAsync(new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [1, 4, 1, 4],
+        });
+
+        result.Should().Be(expected);
+        A.CallTo(() => ingredientRepository.CreateIngredientAsync(
+                A<NewIngredient>.That.Matches(i =>
+                    i.Name == IngredientName.From("Sugar") &&
+                    i.UnitIds.Count == 2 &&
+                    i.UnitIds.Contains(1) &&
+                    i.UnitIds.Contains(4))))
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -1,5 +1,6 @@
-﻿﻿using MenuDB;
+using MenuDB;
 using MenuDB.Data;
+using MenuApi.Exceptions;
 using MenuApi.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 
@@ -39,10 +40,33 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
     {
         ArgumentNullException.ThrowIfNull(newIngredient);
 
+        var normalizedUnitIds = newIngredient.UnitIds.Distinct().ToList();
+        var existingIngredients = await db.Ingredients
+            .Where(i => i.Name == newIngredient.Name.Value)
+            .Include(i => i.IngredientUnits)
+                .ThenInclude(iu => iu.Unit)
+                    .ThenInclude(u => u.UnitType)
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        var existingEquivalentIngredient = existingIngredients
+            .FirstOrDefault(i => i.IngredientUnits.Select(iu => iu.UnitId).ToHashSet().SetEquals(normalizedUnitIds));
+
+        if (existingEquivalentIngredient is not null)
+        {
+            return MapIngredient(existingEquivalentIngredient);
+        }
+
+        if (existingIngredients.Count != 0)
+        {
+            throw new BusinessValidationException(
+                $"Ingredient '{newIngredient.Name.Value}' already exists with a different unit set.");
+        }
+
         var entity = new IngredientEntity
         {
             Name = newIngredient.Name.Value,
-            IngredientUnits = newIngredient.UnitIds
+            IngredientUnits = normalizedUnitIds
                 .Select(unitId => new IngredientUnitEntity { UnitId = unitId })
                 .ToList(),
         };
@@ -51,28 +75,27 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
 
         var created = await db.Ingredients
             .Where(i => i.Id == entity.Id)
-            .Select(i => new
-            {
-                i.Id,
-                i.Name,
-                Units = i.IngredientUnits.Select(iu => new
-                {
-                    iu.Unit.Name,
-                    iu.Unit.Abbreviation,
-                    UnitType = iu.Unit.UnitType.Name,
-                })
-            })
+            .Include(i => i.IngredientUnits)
+                .ThenInclude(iu => iu.Unit)
+                    .ThenInclude(u => u.UnitType)
             .FirstAsync()
             .ConfigureAwait(false);
 
+        return MapIngredient(created);
+    }
+
+    private static ViewModel.Ingredient MapIngredient(IngredientEntity ingredient)
+    {
         return new ViewModel.Ingredient
         {
-            Id = IngredientId.From(created.Id),
-            Name = IngredientName.From(created.Name),
-            Units = created.Units.Select(u => new ViewModel.IngredientUnit(
-                IngredientUnitName.From(u.Name),
-                u.Abbreviation is not null ? IngredientUnitAbbreviation.From(u.Abbreviation) : null,
-                IngredientUnitType.From(u.UnitType))),
+            Id = IngredientId.From(ingredient.Id),
+            Name = IngredientName.From(ingredient.Name),
+            Units = ingredient.IngredientUnits
+                .OrderBy(iu => iu.UnitId)
+                .Select(iu => new ViewModel.IngredientUnit(
+                    IngredientUnitName.From(iu.Unit.Name),
+                    iu.Unit.Abbreviation is not null ? IngredientUnitAbbreviation.From(iu.Unit.Abbreviation) : null,
+                    IngredientUnitType.From(iu.Unit.UnitType.Name))),
         };
     }
 }

--- a/backend/MenuApi/Services/IngredientService.cs
+++ b/backend/MenuApi/Services/IngredientService.cs
@@ -14,7 +14,15 @@ public class IngredientService(IUnitRepository unitRepository, IIngredientReposi
 
     public async Task<Ingredient> CreateIngredientAsync(NewIngredient newIngredient)
     {
-        return await ingredientRepository.CreateIngredientAsync(newIngredient).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(newIngredient);
+
+        var normalizedIngredient = new NewIngredient
+        {
+            Name = newIngredient.Name,
+            UnitIds = [.. newIngredient.UnitIds.Distinct()],
+        };
+
+        return await ingredientRepository.CreateIngredientAsync(normalizedIngredient).ConfigureAwait(false);
     }
 }
 

--- a/backend/MenuDB/MenuDbContext.cs
+++ b/backend/MenuDB/MenuDbContext.cs
@@ -20,6 +20,7 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).UseIdentityColumn();
             e.Property(x => x.Name).HasColumnType("varchar(500)").IsRequired();
+            e.HasIndex(x => x.Name).IsUnique();
         });
 
         modelBuilder.Entity<IngredientEntity>(e =>
@@ -28,6 +29,7 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).UseIdentityColumn();
             e.Property(x => x.Name).HasColumnType("varchar(50)").IsRequired();
+            e.HasIndex(x => x.Name).IsUnique();
         });
 
         modelBuilder.Entity<UnitTypeEntity>(e =>

--- a/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.Designer.cs
+++ b/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.Designer.cs
@@ -3,6 +3,7 @@ using MenuDB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MenuDB.Migrations
 {
     [DbContext(typeof(MenuDbContext))]
-    partial class MenuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503213945_AddBusinessUniqueIndexes")]
+    partial class AddBusinessUniqueIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.cs
+++ b/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MenuDB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBusinessUniqueIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                IF EXISTS (
+                    SELECT [Name]
+                    FROM [Recipe]
+                    GROUP BY [Name]
+                    HAVING COUNT(*) > 1
+                )
+                BEGIN
+                    THROW 50000, 'Cannot apply AddBusinessUniqueIndexes while duplicate Recipe.Name rows exist. Remediate duplicate recipe names before retrying the migration.', 1;
+                END;
+                """);
+
+            migrationBuilder.Sql(
+                """
+                IF EXISTS (
+                    SELECT [Name]
+                    FROM [Ingredient]
+                    GROUP BY [Name]
+                    HAVING COUNT(*) > 1
+                )
+                BEGIN
+                    THROW 50000, 'Cannot apply AddBusinessUniqueIndexes while duplicate Ingredient.Name rows exist. Remediate duplicate ingredient names before retrying the migration.', 1;
+                END;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recipe_Name",
+                table: "Recipe",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ingredient_Name",
+                table: "Ingredient",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Recipe_Name",
+                table: "Recipe");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Ingredient_Name",
+                table: "Ingredient");
+        }
+    }
+}

--- a/docs/specs/backend-write-duplicate-risk-audit.md
+++ b/docs/specs/backend-write-duplicate-risk-audit.md
@@ -89,6 +89,39 @@ This audit inventories every backend write endpoint under `backend/MenuApi/Recip
 5. `NewRecipeValidator` and `RecipeIngredientValidator` validate shape and value ranges, but they do not reject duplicate `(ingredient, unit)` pairs in the same request.
 6. The repository write paths rely on database primary keys to reject duplicate join-table rows instead of preventing duplicate attempts earlier.
 
+## Schema Hardening and Remediation Plan (2026-05-03T21:56:25.759+01:00)
+
+### Unique indexes to add
+
+- `Ingredient.Name` — canonical ingredient rows are now reused in the application layer, so the database can enforce one stored definition per ingredient name.
+- `Recipe.Name` — recipe names are business-significant and must be unique before the API can expose duplicate conflicts cleanly.
+
+### Pre-migration duplicate audit queries
+
+Run these checks before applying the uniqueness migration to any existing environment:
+
+```sql
+SELECT [Name], COUNT(*) AS [Count]
+FROM [Ingredient]
+GROUP BY [Name]
+HAVING COUNT(*) > 1;
+
+SELECT [Name], COUNT(*) AS [Count]
+FROM [Recipe]
+GROUP BY [Name]
+HAVING COUNT(*) > 1;
+```
+
+### Remediation steps if duplicates exist
+
+1. **Ingredient duplicates:** choose the canonical row to keep per duplicated name, update any `RecipeIngredient` references to point to that retained ingredient row, delete orphaned `IngredientUnit` links for removed rows, then delete the duplicate `Ingredient` rows.
+2. **Recipe duplicates:** choose the retained recipe record per duplicated name and either rename, merge, or remove the extras according to product intent before the uniqueness migration is retried.
+3. Re-run the duplicate audit queries until they return zero rows, then apply the migration.
+
+### Deployment note
+
+`Recipe.Name` uniqueness is intended to pair with issue #980's explicit conflict handling so duplicate recipe writes surface as controlled API responses rather than raw database failures.
+
 ## Duplicate-Handling Policy Buckets
 
 > **Note:** The sections below describe **target / intended** behaviour, not the current runtime behaviour described above. The current write paths do not yet implement these policies.


### PR DESCRIPTION
## Summary
- add unique database indexes for business-unique ingredient and recipe names
- fail the migration early with actionable duplicate-data remediation guidance before creating the new indexes
- add model verification tests and update the duplicate-risk audit with pre-deployment cleanup steps

## Testing
- dotnet test --project .\backend\MenuApi.Tests\MenuApi.Tests.csproj
- dotnet test --project .\backend\MenuApi.Integration.Tests\MenuApi.Integration.Tests.csproj
- dotnet ef migrations script --idempotent --project .\backend\MenuDB\MenuDB.csproj --startup-project .\backend\MenuApi\MenuApi.csproj

Closes #979