### PR TITLE
Expose explicit duplicate conflict responses

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -1,0 +1,47 @@
+# Project Context
+
+- **Owner:** Daniel Gee
+- **Project:** Menu
+- **Stack:** Vue 3, Quasar, TypeScript, C#/.NET, EF Core, Aspire
+- **Description:** Recipe management app for customers to save and access recipes easily.
+- **Created:** 2026-05-03T21:56:25.759+01:00
+
+## Team Assignments (2026-05-03T21:56:25.759+01:00)
+
+### Active Work
+
+**Issues:** #977, #978, #979, #980 (duplicate prevention epic)
+
+- **#977** (Prevent duplicate inserts — set-like) — PR opened / clean handoff
+- **#978** (Prevent duplicate inserts — canonical) — Implemented
+- **#979** (Add uniqueness constraints) — Depends on #977/#978
+- **#980** (Expose explicit duplicate conflicts) — Final step
+
+**Label:** `squad:basher`
+
+## Learnings
+
+- Backend stack is C#/.NET with Aspire orchestration.
+- Backend code lives under `backend/`.
+- Recipe persistence and API behavior are core product responsibilities.
+- Duplicate handling work is sequenced: service/repo logic → schema constraints → API contract.
+- Exact duplicate handling for set-like writes now normalizes request payloads in `backend/MenuApi/Services/IngredientService.cs` and `backend/MenuApi/Services/RecipeService.cs` before repository calls.
+- Repository write paths also stay defensive: `backend/MenuApi/Repositories/IngredientRepository.cs` deduplicates `UnitIds`, and `backend/MenuApi/Repositories/RecipeRepository.cs` deduplicates exact `RecipeIngredient` records before upsert.
+- Regression coverage for duplicate-equivalent write requests lives in `backend/MenuApi.Tests/Services/IngredientServiceTests.cs`, `backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs`, `backend/MenuApi.Tests/Services/RecipeServiceTests.cs`, `backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs`, and `backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs`.
+- Canonical ingredient writes now normalize `UnitIds` in `backend/MenuApi/Services/IngredientService.cs` before repository comparison so equivalent payloads match existing rows regardless of order or repetition.
+- `backend/MenuApi/Repositories/IngredientRepository.cs` now performs lookup-before-insert by ingredient name, reuses equivalent canonical rows, and blocks differing unit-set redefinitions before a duplicate row is written.
+- Canonical-row reuse coverage lives in `backend/MenuApi.Tests/Services/IngredientServiceTests.cs`, `backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs`, and `backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs`.
+
+### Issue #977: Duplicate Prevention (2026-05-03T21:56:25.759+01:00)
+
+- **Status:** ✅ PR opened / clean handoff
+- **Decision:** Treat exact duplicate entries on set-like writes as idempotent in both service and repository layers
+- **Scope:** `POST /api/ingredient`, `POST /api/recipe`, and `PUT /api/recipe/{recipeId}`
+- **Rationale:** Normalization keeps existing success responses unchanged; prevents duplicate inserts against composite-key child tables
+
+### Issue #978: Canonical Ingredient Reuse (2026-05-03T21:56:25.759+01:00)
+
+- **Status:** ✅ Implemented
+- **Decision:** Canonical ingredient creation now reuses an existing same-name row only when the normalized unit-id set is equivalent; otherwise the write is rejected before insert.
+- **Scope:** `POST /api/ingredient`
+- **Rationale:** Ingredient names are later resolved by name in recipe writes, so allowing multiple persisted definitions for the same canonical ingredient would keep lookups ambiguous and block safe uniqueness constraints in #979.

--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -34,6 +34,8 @@
 - Confirmed business-unique columns are currently `backend/MenuDB\Data\IngredientEntity.Name` and `backend/MenuDB\Data\RecipeEntity.Name`; `backend/MenuDB\MenuDbContext.cs` now enforces both with unique indexes.
 - Migration `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs` now pre-checks for duplicate `Ingredient.Name` and `Recipe.Name` rows before creating unique indexes so deployments fail with actionable remediation guidance instead of opaque SQL index errors.
 - Schema hardening verification now includes model-metadata tests in `backend/MenuApi.Tests\Database\MenuDbContextTests.cs` plus an idempotent migration script generation check (`dotnet ef migrations script --idempotent --project MenuDB --startup-project MenuApi`).
+- Duplicate policy is now contract-visible only where meaning changes: `backend/MenuApi/Repositories/IngredientRepository.cs` throws `ConflictException` for canonical ingredient redefinition, while `backend/MenuApi/Services/RecipeService.cs` maps same-name recipe collisions to 409 conflicts and conflicting duplicate recipe ingredient amounts to 400 validation problems.
+- API contract metadata for duplicate-visible writes now advertises 409 responses in `backend/MenuApi/Recipes/IngredientApi.cs` and `backend/MenuApi/Recipes/RecipeApi.cs`, and custom exception handlers in `backend/MenuApi/Exceptions/` keep conflict and validation payloads aligned with Problem Details responses.
 
 ### Issue #977: Duplicate Prevention (2026-05-03T21:56:25.759+01:00)
 
@@ -51,7 +53,14 @@
 
 ### Issue #979: Schema Hardening (2026-05-03T21:56:25.759+01:00)
 
-- **Status:** ✅ Implemented
+- **Status:** ✅ PR opened / clean handoff
 - **Decision:** Add database-enforced unique indexes for `Ingredient.Name` and `Recipe.Name`, and make the migration fail early with explicit remediation guidance if duplicate data already exists.
 - **Scope:** `backend/MenuDB\MenuDbContext.cs`, `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs`, and `docs/specs/backend-write-duplicate-risk-audit.md`
 - **Rationale:** Application-layer normalization now covers canonical ingredients, and the remaining business-unique names need schema enforcement before duplicate handling can be completed cleanly in #980.
+
+### Issue #980: Explicit Duplicate Conflicts (2026-05-03T21:56:25.759+01:00)
+
+- **Status:** ✅ Implemented / validated
+- **Decision:** Surface only business-significant duplicates as client-visible errors: canonical redefinitions and recipe-name collisions return 409 conflict responses, while conflicting duplicate ingredient amounts inside one recipe payload return a 400 validation problem.
+- **Scope:** `POST /api/ingredient`, `POST /api/recipe`, `PUT /api/recipe/{recipeId}`, and the duplicate-specific exception handling in `backend/MenuApi/Exceptions/`.
+- **Rationale:** Exact duplicate set-like items and equivalent canonical rows remain idempotent, so the API contract only changes for duplicates that would otherwise hide a real business conflict.

--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -31,6 +31,9 @@
 - Canonical ingredient writes now normalize `UnitIds` in `backend/MenuApi/Services/IngredientService.cs` before repository comparison so equivalent payloads match existing rows regardless of order or repetition.
 - `backend/MenuApi/Repositories/IngredientRepository.cs` now performs lookup-before-insert by ingredient name, reuses equivalent canonical rows, and blocks differing unit-set redefinitions before a duplicate row is written.
 - Canonical-row reuse coverage lives in `backend/MenuApi.Tests/Services/IngredientServiceTests.cs`, `backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs`, and `backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs`.
+- Confirmed business-unique columns are currently `backend/MenuDB\Data\IngredientEntity.Name` and `backend/MenuDB\Data\RecipeEntity.Name`; `backend/MenuDB\MenuDbContext.cs` now enforces both with unique indexes.
+- Migration `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs` now pre-checks for duplicate `Ingredient.Name` and `Recipe.Name` rows before creating unique indexes so deployments fail with actionable remediation guidance instead of opaque SQL index errors.
+- Schema hardening verification now includes model-metadata tests in `backend/MenuApi.Tests\Database\MenuDbContextTests.cs` plus an idempotent migration script generation check (`dotnet ef migrations script --idempotent --project MenuDB --startup-project MenuApi`).
 
 ### Issue #977: Duplicate Prevention (2026-05-03T21:56:25.759+01:00)
 
@@ -41,7 +44,14 @@
 
 ### Issue #978: Canonical Ingredient Reuse (2026-05-03T21:56:25.759+01:00)
 
-- **Status:** ✅ Implemented
+- **Status:** ✅ PR opened / clean handoff
 - **Decision:** Canonical ingredient creation now reuses an existing same-name row only when the normalized unit-id set is equivalent; otherwise the write is rejected before insert.
 - **Scope:** `POST /api/ingredient`
 - **Rationale:** Ingredient names are later resolved by name in recipe writes, so allowing multiple persisted definitions for the same canonical ingredient would keep lookups ambiguous and block safe uniqueness constraints in #979.
+
+### Issue #979: Schema Hardening (2026-05-03T21:56:25.759+01:00)
+
+- **Status:** ✅ Implemented
+- **Decision:** Add database-enforced unique indexes for `Ingredient.Name` and `Recipe.Name`, and make the migration fail early with explicit remediation guidance if duplicate data already exists.
+- **Scope:** `backend/MenuDB\MenuDbContext.cs`, `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs`, and `docs/specs/backend-write-duplicate-risk-audit.md`
+- **Rationale:** Application-layer normalization now covers canonical ingredients, and the remaining business-unique names need schema enforcement before duplicate handling can be completed cleanly in #980.

--- a/.squad/decisions/inbox/basher-issue-977.md
+++ b/.squad/decisions/inbox/basher-issue-977.md
@@ -1,0 +1,6 @@
+# Basher decision — issue #977
+
+- Date: 2026-05-03T21:56:25.759+01:00
+- Decision: Treat exact duplicate entries on set-like backend writes as idempotent in both service and repository layers.
+- Scope: `POST /api/ingredient`, `POST /api/recipe`, and `PUT /api/recipe/{recipeId}`.
+- Rationale: Normalizing duplicate-equivalent payload items before persistence keeps existing success responses unchanged and prevents duplicate insert attempts against composite-key child/link tables. Conflicting duplicates remain out of scope here and stay available for explicit validation work in issue #980.

--- a/.squad/decisions/inbox/basher-issue-978.md
+++ b/.squad/decisions/inbox/basher-issue-978.md
@@ -1,0 +1,6 @@
+# Basher decision — issue #978
+
+- Date: 2026-05-03T21:56:25.759+01:00
+- Decision: For canonical ingredient rows, normalize incoming `UnitIds`, reuse an existing same-name ingredient when the effective unit set matches, and block mismatched redefinitions before insert.
+- Scope: `POST /api/ingredient`
+- Rationale: Ingredient rows behave as reference data for recipe writes, so the backend must perform lookup-before-insert to keep name-based resolution unambiguous and to prepare the schema for uniqueness constraints in #979.

--- a/.squad/decisions/inbox/basher-issue-979.md
+++ b/.squad/decisions/inbox/basher-issue-979.md
@@ -1,0 +1,6 @@
+# Basher decision — issue #979
+
+- Date: 2026-05-03T21:56:25.759+01:00
+- Decision: Enforce uniqueness at the database level for `Ingredient.Name` and `Recipe.Name`, and gate the migration with duplicate-data checks that fail fast with remediation instructions.
+- Scope: `backend/MenuDB\MenuDbContext.cs`, `backend/MenuDB\Migrations\20260503213945_AddBusinessUniqueIndexes.cs`, and `docs/specs/backend-write-duplicate-risk-audit.md`
+- Rationale: These are the confirmed business-unique names in the duplicate-prevention epic. Failing the migration before index creation keeps deployment risk explicit and prepares #980 to translate remaining duplicate-name writes into deliberate API responses.

--- a/.squad/decisions/inbox/basher-issue-980.md
+++ b/.squad/decisions/inbox/basher-issue-980.md
@@ -1,0 +1,6 @@
+# Basher decision — issue #980
+
+- Date: 2026-05-03T21:56:25.759+01:00
+- Decision: Surface only business-significant duplicate writes as explicit API errors: return 409 conflicts for canonical redefinitions and recipe-name collisions, and return a 400 validation problem for conflicting duplicate recipe ingredient amounts within one payload.
+- Scope: `backend/MenuApi\Recipes\IngredientApi.cs`, `backend/MenuApi\Recipes\RecipeApi.cs`, `backend/MenuApi\Services\RecipeService.cs`, `backend/MenuApi\Repositories\IngredientRepository.cs`, and `backend/MenuApi\Exceptions\`.
+- Rationale: The duplicate-handling policy already treats exact set-like duplicates and equivalent canonical rows as idempotent. Making only the meaning-changing cases client-visible keeps the contract narrow, aligns with the new schema guarantees from #979, and gives callers actionable problem details when a write would otherwise redefine an existing business concept.

--- a/.squad/skills/canonical-reference-row-reuse/SKILL.md
+++ b/.squad/skills/canonical-reference-row-reuse/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: "canonical-reference-row-reuse"
+description: "Reuse existing canonical ingredient rows by normalized definition before inserting new reference data"
+domain: "backend"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this pattern when a Menu backend write creates reference data that should have one canonical stored definition, and future writes resolve that data by a business key rather than by surrogate ID.
+
+## Patterns
+- Normalize request collections before comparison so equivalent payloads match regardless of ordering or repeated IDs.
+- Query by the canonical business key (`Ingredient.Name`) before insert and compare the effective definition (`UnitIds` set) against existing rows.
+- Reuse the existing row when the normalized definitions match; return the existing API shape so the behavior stays client-transparent for equivalent requests.
+- Reject mismatched redefinitions before insert so later schema constraints can rely on a single persisted definition per canonical key.
+
+## Examples
+```csharp
+var normalizedUnitIds = newIngredient.UnitIds.Distinct().ToList();
+var existingEquivalentIngredient = existingIngredients
+    .FirstOrDefault(i => i.IngredientUnits.Select(iu => iu.UnitId).ToHashSet().SetEquals(normalizedUnitIds));
+
+if (existingEquivalentIngredient is not null)
+{
+    return MapIngredient(existingEquivalentIngredient);
+}
+```
+
+## Anti-Patterns
+- Comparing raw request lists without deduplicating or ignoring order first.
+- Inserting a second reference row with the same canonical name and hoping later code will "pick the right one".
+- Reusing an existing canonical row when the incoming definition differs in a business-significant way.

--- a/.squad/skills/duplicate-conflict-problem-details/SKILL.md
+++ b/.squad/skills/duplicate-conflict-problem-details/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "duplicate-conflict-problem-details"
+description: "Expose only business-significant duplicate writes as 409 conflict or 400 validation Problem Details responses"
+domain: "backend"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this pattern when Menu's duplicate-handling policy distinguishes between idempotent duplicates that should be silently normalized and duplicate inputs that would change business meaning if they were accepted or collapsed.
+
+## Patterns
+- Keep exact set-like duplicates and equivalent canonical writes idempotent; do not surface them as client-visible errors.
+- Throw `ConflictException` when a duplicate collides with an existing canonical or business-unique resource definition, such as a same-name ingredient with a different unit set or a same-name recipe targeting a different record.
+- Throw `RequestValidationException` when the conflict exists entirely inside one request payload, such as duplicate recipe ingredient keys carrying different amounts.
+- Register dedicated exception handlers that emit RFC 9110 Problem Details / ValidationProblemDetails responses, and advertise the new 409 response shapes in endpoint metadata where the contract is intentionally changing.
+- Cover both success-path normalization and explicit duplicate errors with integration tests so the API contract stays narrow and deliberate.
+
+## Examples
+```csharp
+if (await recipeRepository.RecipeNameExistsAsync(newRecipe.Name, recipeId).ConfigureAwait(false))
+{
+    throw new ConflictException($"Recipe '{newRecipe.Name.Value}' already exists.");
+}
+
+if (conflictingDuplicates.Length != 0)
+{
+    throw new RequestValidationException(new Dictionary<string, string[]>
+    {
+        ["ingredients"] = conflictingDuplicates,
+    });
+}
+```
+
+## Anti-Patterns
+- Returning 409 for duplicate-equivalent requests that should remain idempotent.
+- Silently collapsing conflicting duplicates inside a single payload and hiding the caller mistake.
+- Reusing generic 422 business-validation responses when the API now has a clearer duplicate-conflict contract.

--- a/.squad/skills/set-like-write-dedupe/SKILL.md
+++ b/.squad/skills/set-like-write-dedupe/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: "set-like-write-dedupe"
+description: "Normalize exact duplicates for set-like backend writes before child or junction table persistence"
+domain: "backend"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this pattern when a Menu backend request carries a set-like collection whose duplicates add no business meaning, but the persistence layer writes child rows or junction-table links that would otherwise attempt duplicate inserts.
+
+## Patterns
+- Normalize duplicate-equivalent request items in the service layer before calling repositories so the request becomes idempotent without changing the API contract.
+- Repeat the dedupe defensively in repository write paths before creating child/link entities; repository methods should stay safe even if a future caller skips the service.
+- For `RecipeIngredient` inputs, only collapse **exact** duplicates (`IngredientName`, `UnitName`, and `Amount` all match). Leave conflicting duplicates to explicit validation behavior.
+- For junction-table ID collections like `UnitIds`, deduplicate by the identifier value before materializing `IngredientUnitEntity` rows.
+
+## Examples
+```csharp
+var normalizedIngredient = new NewIngredient
+{
+    Name = newIngredient.Name,
+    UnitIds = [.. newIngredient.UnitIds.Distinct()],
+};
+
+var ingredients = [.. ViewModelMapper.Map(newRecipe.Ingredients).Distinct()];
+```
+
+## Anti-Patterns
+- Deduplicating only at the database boundary and leaving service calls free to send unstable duplicate payloads downstream.
+- Collapsing conflicting duplicates that should stay available for a later validation or conflict response.
+- Assuming composite primary keys are enough; they block persisted duplicates but do not stop duplicate insert attempts from request payloads.

--- a/.squad/skills/unique-index-migration-guards/SKILL.md
+++ b/.squad/skills/unique-index-migration-guards/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: "unique-index-migration-guards"
+description: "Add duplicate-data guard SQL before creating business-unique indexes in Menu migrations"
+domain: "backend"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this pattern when Menu adds a new unique index for a business key and existing shared environments may already contain duplicate rows that would make the migration fail at deploy time.
+
+## Patterns
+- Add the unique index in `MenuDbContext` so the EF model, snapshot, and generated migration stay aligned.
+- Keep the migration focused on the unique-index change, but prepend explicit SQL duplicate checks for each constrained table before `CreateIndex(... unique: true)`.
+- Make the guard SQL throw a specific remediation message naming the affected business key so deployment failures explain exactly what data must be cleaned up.
+- Document the pre-deployment duplicate audit queries and cleanup steps in existing backend docs when the migration affects shared data.
+
+## Examples
+```csharp
+migrationBuilder.Sql(
+    """
+    IF EXISTS (
+        SELECT [Name]
+        FROM [Recipe]
+        GROUP BY [Name]
+        HAVING COUNT(*) > 1
+    )
+    BEGIN
+        THROW 50000, 'Cannot apply AddBusinessUniqueIndexes while duplicate Recipe.Name rows exist. Remediate duplicate recipe names before retrying the migration.', 1;
+    END;
+    """);
+```
+
+## Anti-Patterns
+- Adding a unique index without checking whether existing shared data can satisfy it.
+- Relying on raw SQL Server error 1505 output as the only remediation signal for deployments.
+- Documenting cleanup steps only in PR text instead of in durable repo docs tied to the migration.

--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -87,6 +87,29 @@ public class IngredientIntegrationTests : IClassFixture<ApiTestFixture>
         ingredients.Should().Contain(i => i.Id == createdId && i.Name == ingredientName);
     }
 
+    [Theory, ShortStringAutoData]
+    public async Task Create_Ingredient_Reuses_Equivalent_Existing_Canonical_Row(string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var (firstId, _, _) = await PostIngredientAsync(client, ingredientName, [1, 4]);
+        var (secondId, secondName, secondUnits) = await PostIngredientAsync(client, ingredientName, [4, 1, 4]);
+
+        secondId.Should().Be(firstId);
+        secondName.Should().Be(ingredientName);
+        secondUnits.Should().HaveCount(2);
+        secondUnits.Should().ContainSingle(u => u.Name == "Millilitres");
+        secondUnits.Should().ContainSingle(u => u.Name == "Grams");
+
+        using var response = await client.GetAsync("/api/ingredient");
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        var data = await response.Content.ReadAsStringAsync();
+        var ingredients = JsonSerializer.Deserialize<List<Ingredient>>(data, jsonOptions);
+        ingredients.Should().NotBeNull();
+        ingredients.Where(i => i.Name == ingredientName).Should().ContainSingle(i => i.Id == firstId);
+    }
+
     internal async Task<(int Id, string Name, List<IngredientUnit> Units)> PostIngredientAsync(
         HttpClient client, string name, List<int> unitIds)
     {

--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -88,6 +88,19 @@ public class IngredientIntegrationTests : IClassFixture<ApiTestFixture>
     }
 
     [Theory, ShortStringAutoData]
+    public async Task Create_Ingredient_With_Duplicate_Units_Returns_Unique_Units(string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var (_, name, units) = await PostIngredientAsync(client, ingredientName, [1, 1, 4, 4]);
+
+        name.Should().Be(ingredientName);
+        units.Should().HaveCount(2);
+        units.Should().ContainSingle(u => u.Name == "Millilitres");
+        units.Should().ContainSingle(u => u.Name == "Grams");
+    }
+
+    [Theory, ShortStringAutoData]
     public async Task Create_Ingredient_Reuses_Equivalent_Existing_Canonical_Row(string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
@@ -108,6 +121,25 @@ public class IngredientIntegrationTests : IClassFixture<ApiTestFixture>
         var ingredients = JsonSerializer.Deserialize<List<Ingredient>>(data, jsonOptions);
         ingredients.Should().NotBeNull();
         ingredients.Where(i => i.Name == ingredientName).Should().ContainSingle(i => i.Id == firstId);
+    }
+
+    [Theory, ShortStringAutoData]
+    public async Task Create_Ingredient_With_Different_Unit_Set_Returns_Conflict(string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [1]);
+
+        var body = new NewIngredient { Name = ingredientName, UnitIds = [1, 4] };
+        using var requestContent = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/ingredient", requestContent);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.Conflict);
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        jsonDoc.RootElement.GetProperty("status").GetInt32().Should().Be((int)HttpStatusCode.Conflict);
+        jsonDoc.RootElement.GetProperty("detail").GetString().Should().Be($"Ingredient '{ingredientName}' already exists with a different unit set.");
     }
 
     internal async Task<(int Id, string Name, List<IngredientUnit> Units)> PostIngredientAsync(

--- a/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -55,14 +55,38 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
         name.Should().Be(recipe.Name);
     }
 
-    [Theory, AutoData]
+    [Theory, ShortStringAutoData]
+    public async Task Create_Recipe_With_Duplicate_Name_Returns_Conflict(string recipeName, string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+
+        var recipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }],
+        };
+
+        await PostRecipeAsync(client, recipe);
+
+        using var requestContent = new StringContent(JsonSerializer.Serialize(recipe), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", requestContent);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.Conflict);
+
+        using var streamResponse = await response.Content.ReadAsStreamAsync();
+        using var jsonDoc = await JsonDocument.ParseAsync(streamResponse);
+        jsonDoc.RootElement.GetProperty("detail").GetString().Should().Be($"Recipe '{recipeName}' already exists.");
+    }
+
+    [Theory, ShortStringAutoData]
     public async Task Create_and_Update_Recipe(
-        [NoAutoProperties] NewRecipe recipe,
-        [StringLength(500, MinimumLength = 1)] string recipeName,
-        [NoAutoProperties] NewRecipe updatedRecipe,
-        [StringLength(500, MinimumLength = 1)] string updatedRecipeName,
-        [StringLength(50, MinimumLength = 1)] string ingredientName,
-        [StringLength(50, MinimumLength = 1)] string ingredientName2)
+        NewRecipe recipe,
+        string recipeName,
+        NewRecipe updatedRecipe,
+        string updatedRecipeName,
+        string ingredientName,
+        string ingredientName2)
     {
         using var client = await fixture.GetHttpClient();
         await PostIngredientAsync(client, ingredientName);
@@ -79,11 +103,46 @@ public class RecipeIntegrationTests : IClassFixture<ApiTestFixture>
         name.Should().Be(updatedRecipe.Name);
     }
 
-    [Theory, AutoData]
-    public async Task Create_And_Get_Recipe(
-        [NoAutoProperties] NewRecipe recipe,
-        [StringLength(500, MinimumLength = 1)] string recipeName,
-        [StringLength(50, MinimumLength = 1)] string ingredientName)
+    [Theory, ShortStringAutoData]
+    public async Task Update_Recipe_With_Duplicate_Name_Returns_Conflict(
+        string recipeName,
+        string otherRecipeName,
+        string ingredientName,
+        string otherIngredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+        await PostIngredientAsync(client, otherIngredientName);
+
+        var recipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }],
+        };
+
+        var otherRecipe = new NewRecipe
+        {
+            Name = otherRecipeName,
+            Ingredients = [new RecipeIngredient { Name = otherIngredientName, Unit = Grams, Amount = 200 }],
+        };
+
+        await PostRecipeAsync(client, recipe);
+        var (otherRecipeId, _) = await PostRecipeAsync(client, otherRecipe);
+
+        otherRecipe.Name = recipeName;
+
+        using var requestContent = new StringContent(JsonSerializer.Serialize(otherRecipe), Encoding.UTF8, "application/json");
+        using var response = await client.PutAsync($"/api/recipe/{otherRecipeId}", requestContent);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.Conflict);
+
+        using var streamResponse = await response.Content.ReadAsStreamAsync();
+        using var jsonDoc = await JsonDocument.ParseAsync(streamResponse);
+        jsonDoc.RootElement.GetProperty("detail").GetString().Should().Be($"Recipe '{recipeName}' already exists.");
+    }
+
+    [Theory, ShortStringAutoData]
+    public async Task Create_And_Get_Recipe(NewRecipe recipe, string recipeName, string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
         await PostIngredientAsync(client, ingredientName);

--- a/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
@@ -54,6 +54,61 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
         returnedIngredients[0].Amount.Should().Be(250.5m);
     }
 
+    [Theory, ShortStringAutoData]
+    public async Task Create_Recipe_With_Duplicate_Equivalent_Ingredients_Returns_Single_Link(
+        string ingredientName, string recipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var newRecipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 250.5m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 250.5m },
+            ]
+        };
+
+        var (_, returnedName, returnedIngredients) = await PostRecipeAsync(client, newRecipe);
+
+        returnedName.Should().Be(recipeName);
+        returnedIngredients.Should().HaveCount(1);
+        returnedIngredients[0].Name.Should().Be(ingredientName);
+        returnedIngredients[0].Unit.Should().Be("Grams");
+        returnedIngredients[0].Amount.Should().Be(250.5m);
+    }
+
+    [Theory, ShortStringAutoData]
+    public async Task Create_Recipe_With_Conflicting_Duplicate_Ingredients_Returns_Validation_Problem(
+        string ingredientName, string recipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var newRecipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 250.5m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m },
+            ]
+        };
+
+        using var content = new StringContent(JsonSerializer.Serialize(newRecipe, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        jsonDoc.RootElement.GetProperty("errors").GetProperty("ingredients")[0].GetString().Should().Contain("different amounts");
+    }
+
     [Theory, AutoData]
     public async Task Create_Recipe_With_Ingredients_Then_Get_Recipe_Returns_Ingredients(
         [StringLength(50, MinimumLength = 1)] string ingredientName,
@@ -177,6 +232,96 @@ public class RecipeWithIngredientsIntegrationTests : IClassFixture<ApiTestFixtur
         ingredients[0].Name.Should().Be(ingredientName2);
         ingredients[0].Unit.Should().Be("Millilitres");
         ingredients[0].Amount.Should().Be(200m);
+    }
+
+    [Theory, ShortStringAutoData]
+    public async Task Update_Recipe_With_Duplicate_Equivalent_Existing_Ingredient_Remains_Single_Link(
+        string ingredientName, string recipeName, string updatedRecipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var newRecipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m }
+            ]
+        };
+
+        var (recipeId, _, _) = await PostRecipeAsync(client, newRecipe);
+
+        var updatedRecipe = new NewRecipe
+        {
+            Name = updatedRecipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 125m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 125m },
+            ]
+        };
+
+        var putContent = new StringContent(JsonSerializer.Serialize(updatedRecipe, jsonOptions), Encoding.UTF8, "application/json");
+        using var putResponse = await client.PutAsync($"/api/recipe/{recipeId}", putContent);
+        await putResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var getResponse = await client.GetAsync($"/api/recipe/{recipeId}");
+        await getResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var getStream = await getResponse.Content.ReadAsStreamAsync();
+        using var getDoc = await JsonDocument.ParseAsync(getStream);
+        var root = getDoc.RootElement;
+
+        root.GetProperty("name").GetString().Should().Be(updatedRecipeName);
+        var ingredients = JsonSerializer.Deserialize<List<RecipeIngredient>>(
+            root.GetProperty("ingredients").GetRawText(), jsonOptions)!;
+        ingredients.Should().HaveCount(1);
+        ingredients[0].Name.Should().Be(ingredientName);
+        ingredients[0].Unit.Should().Be("Grams");
+        ingredients[0].Amount.Should().Be(125m);
+    }
+
+    [Theory, ShortStringAutoData]
+    public async Task Update_Recipe_With_Conflicting_Duplicate_Ingredients_Returns_Validation_Problem(
+        string ingredientName,
+        string recipeName,
+        string updatedRecipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var newRecipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m }
+            ]
+        };
+
+        var (recipeId, _, _) = await PostRecipeAsync(client, newRecipe);
+
+        var updatedRecipe = new NewRecipe
+        {
+            Name = updatedRecipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 125m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m },
+            ]
+        };
+
+        using var putContent = new StringContent(JsonSerializer.Serialize(updatedRecipe, jsonOptions), Encoding.UTF8, "application/json");
+        using var putResponse = await client.PutAsync($"/api/recipe/{recipeId}", putContent);
+
+        await putResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        using var stream = await putResponse.Content.ReadAsStreamAsync();
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        jsonDoc.RootElement.GetProperty("errors").GetProperty("ingredients")[0].GetString().Should().Contain("different amounts");
     }
 
     private async Task PostIngredientAsync(HttpClient client, string name, List<int> unitIds)

--- a/backend/MenuApi.Integration.Tests/ShortStringAutoDataAttribute.cs
+++ b/backend/MenuApi.Integration.Tests/ShortStringAutoDataAttribute.cs
@@ -1,0 +1,21 @@
+using AutoFixture;
+using AutoFixture.Xunit3;
+
+namespace MenuApi.Integration.Tests;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class ShortStringAutoDataAttribute : AutoDataAttribute
+{
+    public ShortStringAutoDataAttribute() : base(() =>
+    {
+        var fixture = new Fixture
+        {
+            RepeatCount = 0,
+        };
+
+        fixture.Register(() => Guid.NewGuid().ToString("N"));
+        return fixture;
+    })
+    {
+    }
+}

--- a/backend/MenuApi.Tests/Database/MenuDbContextTests.cs
+++ b/backend/MenuApi.Tests/Database/MenuDbContextTests.cs
@@ -1,0 +1,43 @@
+using AwesomeAssertions;
+using MenuDB;
+using MenuDB.Data;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MenuApi.Tests.Database;
+
+public class MenuDbContextTests
+{
+    [Fact]
+    public void Ingredient_Name_Has_Unique_Index()
+    {
+        using var db = CreateDbContext();
+
+        var ingredientEntity = db.Model.FindEntityType(typeof(IngredientEntity));
+        var ingredientNameIndex = ingredientEntity!.GetIndexes()
+            .Single(index => index.Properties.Select(property => property.Name).SequenceEqual(["Name"]));
+
+        ingredientNameIndex.IsUnique.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Recipe_Name_Has_Unique_Index()
+    {
+        using var db = CreateDbContext();
+
+        var recipeEntity = db.Model.FindEntityType(typeof(RecipeEntity));
+        var recipeNameIndex = recipeEntity!.GetIndexes()
+            .Single(index => index.Properties.Select(property => property.Name).SequenceEqual(["Name"]));
+
+        recipeNameIndex.IsUnique.Should().BeTrue();
+    }
+
+    private static MenuDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+}

--- a/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
@@ -1,0 +1,99 @@
+using AwesomeAssertions;
+using MenuDB;
+using MenuDB.Data;
+using MenuApi.Exceptions;
+using MenuApi.Repositories;
+using MenuApi.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MenuApi.Tests.Repositories;
+
+public class IngredientRepositoryTests
+{
+    [Fact]
+    public async Task CreateIngredientAsync_Reuses_Equivalent_Canonical_Ingredient()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedUnitGraphAsync(db, cancellationToken);
+        db.Ingredients.Add(new IngredientEntity
+        {
+            Id = 10,
+            Name = "Sugar",
+            IngredientUnits =
+            [
+                new IngredientUnitEntity { UnitId = 1 },
+                new IngredientUnitEntity { UnitId = 4 },
+            ],
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var sut = new IngredientRepository(db);
+
+        var result = await sut.CreateIngredientAsync(new MenuApi.ViewModel.NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [4, 1, 4],
+        });
+
+        result.Id.Should().Be(IngredientId.From(10));
+        result.Name.Should().Be(IngredientName.From("Sugar"));
+        result.Units.Should().HaveCount(2);
+        result.Units.Should().ContainSingle(u => u.Name == IngredientUnitName.From("Millilitres"));
+        result.Units.Should().ContainSingle(u => u.Name == IngredientUnitName.From("Grams"));
+        (await db.Ingredients.CountAsync(i => i.Name == "Sugar", cancellationToken)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateIngredientAsync_Rejects_Canonical_Redefinition()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedUnitGraphAsync(db, cancellationToken);
+        db.Ingredients.Add(new IngredientEntity
+        {
+            Id = 10,
+            Name = "Sugar",
+            IngredientUnits =
+            [
+                new IngredientUnitEntity { UnitId = 1 },
+            ],
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var sut = new IngredientRepository(db);
+
+        var act = async () => await sut.CreateIngredientAsync(new MenuApi.ViewModel.NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [1, 4],
+        });
+
+        await act.Should().ThrowAsync<BusinessValidationException>()
+            .WithMessage("Ingredient 'Sugar' already exists with a different unit set.");
+        (await db.Ingredients.CountAsync(i => i.Name == "Sugar", cancellationToken)).Should().Be(1);
+    }
+
+    private static MenuDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+
+    private static async Task SeedUnitGraphAsync(MenuDbContext db, CancellationToken cancellationToken)
+    {
+        var volumeType = new UnitTypeEntity { Id = 1, Name = "Volume" };
+        var weightType = new UnitTypeEntity { Id = 3, Name = "Weight" };
+
+        db.UnitTypes.AddRange(volumeType, weightType);
+        db.Units.AddRange(
+            new UnitEntity { Id = 1, Name = "Millilitres", Abbreviation = "ml", UnitTypeId = 1, UnitType = volumeType },
+            new UnitEntity { Id = 4, Name = "Grams", Abbreviation = "g", UnitTypeId = 3, UnitType = weightType });
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
@@ -70,7 +70,7 @@ public class IngredientRepositoryTests
             UnitIds = [1, 4],
         });
 
-        await act.Should().ThrowAsync<BusinessValidationException>()
+        await act.Should().ThrowAsync<ConflictException>()
             .WithMessage("Ingredient 'Sugar' already exists with a different unit set.");
         (await db.Ingredients.CountAsync(i => i.Name == "Sugar", cancellationToken)).Should().Be(1);
     }

--- a/backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using MenuDB;
+using MenuDB.Data;
+using MenuApi.Repositories;
+using MenuApi.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MenuApi.Tests.Repositories;
+
+public class RecipeRepositoryTests
+{
+    [Fact]
+    public async Task UpsertRecipeIngredientsAsync_Deduplicates_Exact_Duplicate_New_Links()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedRecipeIngredientGraphAsync(db, cancellationToken);
+        var sut = new RecipeRepository(db);
+
+        await sut.UpsertRecipeIngredientsAsync(
+            RecipeId.From(1),
+            [
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(100m), IngredientUnitName.From("Grams")),
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(100m), IngredientUnitName.From("Grams")),
+            ]);
+
+        var rows = await db.RecipeIngredients
+            .Where(ri => ri.RecipeId == 1)
+            .ToListAsync(cancellationToken);
+
+        rows.Should().HaveCount(1);
+        rows[0].Amount.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task UpsertRecipeIngredientsAsync_Does_Not_ReAdd_Existing_Links_On_Update()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedRecipeIngredientGraphAsync(db, cancellationToken);
+        db.RecipeIngredients.Add(new RecipeIngredientEntity
+        {
+            RecipeId = 1,
+            IngredientId = 10,
+            UnitId = 4,
+            Amount = 50m,
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var sut = new RecipeRepository(db);
+
+        await sut.UpsertRecipeIngredientsAsync(
+            RecipeId.From(1),
+            [
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(75m), IngredientUnitName.From("Grams")),
+                new DBModel.RecipeIngredient(IngredientName.From("Sugar"), IngredientAmount.From(75m), IngredientUnitName.From("Grams")),
+            ]);
+
+        var rows = await db.RecipeIngredients
+            .Where(ri => ri.RecipeId == 1)
+            .ToListAsync(cancellationToken);
+
+        rows.Should().HaveCount(1);
+        rows[0].Amount.Should().Be(75m);
+    }
+
+    [Fact]
+    public async Task RecipeNameExistsAsync_Returns_True_For_Existing_Name()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedRecipeIngredientGraphAsync(db, cancellationToken);
+        var sut = new RecipeRepository(db);
+
+        var exists = await sut.RecipeNameExistsAsync(RecipeName.From("Cake"));
+
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RecipeNameExistsAsync_Ignores_Excluded_Recipe()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedRecipeIngredientGraphAsync(db, cancellationToken);
+        var sut = new RecipeRepository(db);
+
+        var exists = await sut.RecipeNameExistsAsync(RecipeName.From("Cake"), RecipeId.From(1));
+
+        exists.Should().BeFalse();
+    }
+
+    private static MenuDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+
+    private static async Task SeedRecipeIngredientGraphAsync(MenuDbContext db, CancellationToken cancellationToken)
+    {
+        var unitType = new UnitTypeEntity { Id = 1, Name = "Weight" };
+        var unit = new UnitEntity { Id = 4, Name = "Grams", UnitTypeId = unitType.Id, UnitType = unitType };
+        var ingredient = new IngredientEntity { Id = 10, Name = "Sugar" };
+        var recipe = new RecipeEntity { Id = 1, Name = "Cake" };
+
+        db.UnitTypes.Add(unitType);
+        db.Units.Add(unit);
+        db.Ingredients.Add(ingredient);
+        db.Recipes.Add(recipe);
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
@@ -31,12 +31,13 @@ public class IngredientServiceTests
             .Returns(expected);
 
         var sut = new IngredientService(unitRepository, ingredientRepository);
-
-        var result = await sut.CreateIngredientAsync(new NewIngredient
+        var newIngredient = new NewIngredient
         {
             Name = IngredientName.From("Sugar"),
-            UnitIds = [1, 4, 1, 4],
-        });
+            UnitIds = [1, 1, 4, 4],
+        };
+
+        var result = await sut.CreateIngredientAsync(newIngredient);
 
         result.Should().Be(expected);
         A.CallTo(() => ingredientRepository.CreateIngredientAsync(

--- a/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/IngredientServiceTests.cs
@@ -1,0 +1,50 @@
+using AwesomeAssertions;
+using FakeItEasy;
+using MenuApi.Repositories;
+using MenuApi.Services;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Xunit;
+
+namespace MenuApi.Tests.Services;
+
+public class IngredientServiceTests
+{
+    [Fact]
+    public async Task CreateIngredientAsync_Deduplicates_UnitIds_Before_Repository_Call()
+    {
+        var unitRepository = A.Fake<IUnitRepository>();
+        var ingredientRepository = A.Fake<IIngredientRepository>();
+        var expected = new Ingredient
+        {
+            Id = IngredientId.From(1),
+            Name = IngredientName.From("Sugar"),
+            Units = [],
+        };
+
+        A.CallTo(() => ingredientRepository.CreateIngredientAsync(
+                A<NewIngredient>.That.Matches(i =>
+                    i.Name == IngredientName.From("Sugar") &&
+                    i.UnitIds.Count == 2 &&
+                    i.UnitIds.Contains(1) &&
+                    i.UnitIds.Contains(4))))
+            .Returns(expected);
+
+        var sut = new IngredientService(unitRepository, ingredientRepository);
+
+        var result = await sut.CreateIngredientAsync(new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [1, 4, 1, 4],
+        });
+
+        result.Should().Be(expected);
+        A.CallTo(() => ingredientRepository.CreateIngredientAsync(
+                A<NewIngredient>.That.Matches(i =>
+                    i.Name == IngredientName.From("Sugar") &&
+                    i.UnitIds.Count == 2 &&
+                    i.UnitIds.Contains(1) &&
+                    i.UnitIds.Contains(4))))
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using FakeItEasy;
 using MenuDB;
+using MenuApi.Exceptions;
 using MenuApi.Repositories;
 using MenuApi.Services;
 using MenuApi.ValueObjects;
@@ -101,6 +102,84 @@ public class RecipeServiceTests
         A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(recipe.Id, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustHaveHappenedOnceExactly();
     }
 
+    [Fact]
+    public async Task CreateRecipeAsync_Deduplicates_Exact_Duplicate_Ingredients_Before_Upsert()
+    {
+        var recipeId = RecipeId.From(1);
+        var recipeName = RecipeName.From("Cake");
+        var duplicateIngredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m),
+        };
+
+        A.CallTo(() => recipeRepository.CreateRecipeAsync(recipeName)).Returns(recipeId);
+
+        await sut.CreateRecipeAsync(new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [duplicateIngredient, duplicateIngredient],
+        });
+
+        A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(
+                recipeId,
+                A<IEnumerable<DBModel.RecipeIngredient>>.That.Matches(ingredients =>
+                    ingredients.Count() == 1 &&
+                    ingredients.Single() == new DBModel.RecipeIngredient(
+                        IngredientName.From("Sugar"),
+                        IngredientAmount.From(100m),
+                        IngredientUnitName.From("Grams")))))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task CreateRecipeAsync_Throws_Conflict_When_Name_Already_Exists()
+    {
+        var recipeName = RecipeName.From("Cake");
+        A.CallTo(() => recipeRepository.RecipeNameExistsAsync(recipeName)).Returns(true);
+
+        var act = async () => await sut.CreateRecipeAsync(new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [],
+        });
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("Recipe 'Cake' already exists.");
+        A.CallTo(() => recipeRepository.CreateRecipeAsync(A<RecipeName>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task CreateRecipeAsync_Throws_Validation_When_Duplicate_Ingredient_Amounts_Conflict()
+    {
+        var recipeName = RecipeName.From("Cake");
+
+        var act = async () => await sut.CreateRecipeAsync(new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient
+                {
+                    Name = IngredientName.From("Sugar"),
+                    Unit = IngredientUnitName.From("Grams"),
+                    Amount = IngredientAmount.From(100m),
+                },
+                new RecipeIngredient
+                {
+                    Name = IngredientName.From("Sugar"),
+                    Unit = IngredientUnitName.From("Grams"),
+                    Amount = IngredientAmount.From(125m),
+                },
+            ],
+        });
+
+        var result = await act.Should().ThrowAsync<RequestValidationException>();
+        result.Which.Errors["ingredients"].Single().Should().Contain("different amounts");
+        A.CallTo(() => recipeRepository.CreateRecipeAsync(A<RecipeName>._)).MustNotHaveHappened();
+    }
+
     [Theory, CustomAutoData]
     public async Task UpdateRecipeSuccess(RecipeId recipeId, RecipeName recipeName, IEnumerable<DBModel.RecipeIngredient> ingredients)
     {
@@ -119,6 +198,84 @@ public class RecipeServiceTests
 
         A.CallTo(() => recipeRepository.UpdateRecipeAsync(recipeId, recipeName)).MustHaveHappenedOnceExactly();
         A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(recipeId, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UpdateRecipeAsync_Deduplicates_Exact_Duplicate_Ingredients_Before_Upsert()
+    {
+        var recipeId = RecipeId.From(1);
+        var recipeName = RecipeName.From("Cake");
+        var duplicateIngredient = new RecipeIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            Unit = IngredientUnitName.From("Grams"),
+            Amount = IngredientAmount.From(100m),
+        };
+
+        await sut.UpdateRecipeAsync(recipeId, new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [duplicateIngredient, duplicateIngredient],
+        });
+
+        A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(
+                recipeId,
+                A<IEnumerable<DBModel.RecipeIngredient>>.That.Matches(ingredients =>
+                    ingredients.Count() == 1 &&
+                    ingredients.Single() == new DBModel.RecipeIngredient(
+                        IngredientName.From("Sugar"),
+                        IngredientAmount.From(100m),
+                        IngredientUnitName.From("Grams")))))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UpdateRecipeAsync_Throws_Conflict_When_Name_Already_Exists_On_Another_Recipe()
+    {
+        var recipeId = RecipeId.From(1);
+        var recipeName = RecipeName.From("Cake");
+        A.CallTo(() => recipeRepository.RecipeNameExistsAsync(recipeName, recipeId)).Returns(true);
+
+        var act = async () => await sut.UpdateRecipeAsync(recipeId, new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [],
+        });
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("Recipe 'Cake' already exists.");
+        A.CallTo(() => recipeRepository.UpdateRecipeAsync(A<RecipeId>._, A<RecipeName>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UpdateRecipeAsync_Throws_Validation_When_Duplicate_Ingredient_Amounts_Conflict()
+    {
+        var recipeId = RecipeId.From(1);
+        var recipeName = RecipeName.From("Cake");
+
+        var act = async () => await sut.UpdateRecipeAsync(recipeId, new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient
+                {
+                    Name = IngredientName.From("Sugar"),
+                    Unit = IngredientUnitName.From("Grams"),
+                    Amount = IngredientAmount.From(100m),
+                },
+                new RecipeIngredient
+                {
+                    Name = IngredientName.From("Sugar"),
+                    Unit = IngredientUnitName.From("Grams"),
+                    Amount = IngredientAmount.From(125m),
+                },
+            ],
+        });
+
+        var result = await act.Should().ThrowAsync<RequestValidationException>();
+        result.Which.Errors["ingredients"].Single().Should().Contain("different amounts");
+        A.CallTo(() => recipeRepository.UpdateRecipeAsync(A<RecipeId>._, A<RecipeName>._)).MustNotHaveHappened();
     }
 
     [Theory, CustomAutoData]

--- a/backend/MenuApi/Exceptions/ConflictException.cs
+++ b/backend/MenuApi/Exceptions/ConflictException.cs
@@ -1,0 +1,5 @@
+namespace MenuApi.Exceptions;
+
+public class ConflictException(string message) : Exception(message)
+{
+}

--- a/backend/MenuApi/Exceptions/ConflictExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/ConflictExceptionHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MenuApi.Exceptions;
+
+public class ConflictExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not ConflictException conflictException)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
+        httpContext.Response.ContentType = "application/problem+json";
+
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status409Conflict,
+            Title = "Conflict",
+            Detail = conflictException.Message,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.10",
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/MenuApi/Exceptions/RequestValidationException.cs
+++ b/backend/MenuApi/Exceptions/RequestValidationException.cs
@@ -1,0 +1,7 @@
+namespace MenuApi.Exceptions;
+
+public class RequestValidationException(IReadOnlyDictionary<string, string[]> errors)
+    : Exception("One or more validation errors occurred.")
+{
+    public IReadOnlyDictionary<string, string[]> Errors { get; } = errors;
+}

--- a/backend/MenuApi/Exceptions/RequestValidationExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/RequestValidationExceptionHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MenuApi.Exceptions;
+
+public class RequestValidationExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not RequestValidationException validationException)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        httpContext.Response.ContentType = "application/problem+json";
+
+        await httpContext.Response.WriteAsJsonAsync(new ValidationProblemDetails(
+            validationException.Errors.ToDictionary(pair => pair.Key, pair => pair.Value))
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "One or more validation errors occurred.",
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/MenuApi/Program.cs
+++ b/backend/MenuApi/Program.cs
@@ -23,6 +23,8 @@ builder.Services.AddTransient<IIngredientService, IngredientService>();
 builder.Services.AddTransient<IRecipeRepository, RecipeRepository>();
 builder.Services.AddTransient<IRecipeService, RecipeService>();
 
+builder.Services.AddExceptionHandler<RequestValidationExceptionHandler>();
+builder.Services.AddExceptionHandler<ConflictExceptionHandler>();
 builder.Services.AddExceptionHandler<BusinessValidationExceptionHandler>();
 
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();

--- a/backend/MenuApi/Recipes/IngredientApi.cs
+++ b/backend/MenuApi/Recipes/IngredientApi.cs
@@ -22,7 +22,8 @@ public static class IngredientApi
         group.MapPost("/", CreateIngredientAsync)
             .AddEndpointFilter<ValidationFilter<NewIngredient>>()
             .Produces<ViewModel.Ingredient>(StatusCodes.Status200OK)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status409Conflict);
 
         return group;
     }

--- a/backend/MenuApi/Recipes/RecipeApi.cs
+++ b/backend/MenuApi/Recipes/RecipeApi.cs
@@ -27,12 +27,14 @@ public static class RecipeApi
             .AddEndpointFilter<ValidationFilter<NewRecipe>>()
             .Produces<FullRecipe>(StatusCodes.Status200OK)
             .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
 
         group.MapPut("{recipeId}", UpdateRecipeAsync)
             .AddEndpointFilter<ValidationFilter<NewRecipe>>()
             .Produces<FullRecipe>(StatusCodes.Status200OK)
             .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
 
         return group;

--- a/backend/MenuApi/Repositories/IRecipeRepository.cs
+++ b/backend/MenuApi/Repositories/IRecipeRepository.cs
@@ -14,5 +14,9 @@ public interface IRecipeRepository
 
     Task<IEnumerable<DBModel.Recipe>> GetRecipesAsync();
 
+    Task<bool> RecipeNameExistsAsync(RecipeName name);
+
+    Task<bool> RecipeNameExistsAsync(RecipeName name, RecipeId excludedRecipeId);
+
     Task UpdateRecipeAsync(RecipeId recipeId, RecipeName name);
 }

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -1,5 +1,6 @@
-﻿﻿using MenuDB;
+using MenuDB;
 using MenuDB.Data;
+using MenuApi.Exceptions;
 using MenuApi.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 
@@ -39,10 +40,33 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
     {
         ArgumentNullException.ThrowIfNull(newIngredient);
 
+        var normalizedUnitIds = newIngredient.UnitIds.Distinct().ToList();
+        var existingIngredients = await db.Ingredients
+            .Where(i => i.Name == newIngredient.Name.Value)
+            .Include(i => i.IngredientUnits)
+                .ThenInclude(iu => iu.Unit)
+                    .ThenInclude(u => u.UnitType)
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        var existingEquivalentIngredient = existingIngredients
+            .FirstOrDefault(i => i.IngredientUnits.Select(iu => iu.UnitId).ToHashSet().SetEquals(normalizedUnitIds));
+
+        if (existingEquivalentIngredient is not null)
+        {
+            return MapIngredient(existingEquivalentIngredient);
+        }
+
+        if (existingIngredients.Count != 0)
+        {
+            throw new BusinessValidationException(
+                $"Ingredient '{newIngredient.Name.Value}' already exists with a different unit set.");
+        }
+
         var entity = new IngredientEntity
         {
             Name = newIngredient.Name.Value,
-            IngredientUnits = newIngredient.UnitIds
+            IngredientUnits = normalizedUnitIds
                 .Select(unitId => new IngredientUnitEntity { UnitId = unitId })
                 .ToList(),
         };
@@ -51,28 +75,27 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
 
         var created = await db.Ingredients
             .Where(i => i.Id == entity.Id)
-            .Select(i => new
-            {
-                i.Id,
-                i.Name,
-                Units = i.IngredientUnits.Select(iu => new
-                {
-                    iu.Unit.Name,
-                    iu.Unit.Abbreviation,
-                    UnitType = iu.Unit.UnitType.Name,
-                })
-            })
+            .Include(i => i.IngredientUnits)
+                .ThenInclude(iu => iu.Unit)
+                    .ThenInclude(u => u.UnitType)
             .FirstAsync()
             .ConfigureAwait(false);
 
+        return MapIngredient(created);
+    }
+
+    private static ViewModel.Ingredient MapIngredient(IngredientEntity ingredient)
+    {
         return new ViewModel.Ingredient
         {
-            Id = IngredientId.From(created.Id),
-            Name = IngredientName.From(created.Name),
-            Units = created.Units.Select(u => new ViewModel.IngredientUnit(
-                IngredientUnitName.From(u.Name),
-                u.Abbreviation is not null ? IngredientUnitAbbreviation.From(u.Abbreviation) : null,
-                IngredientUnitType.From(u.UnitType))),
+            Id = IngredientId.From(ingredient.Id),
+            Name = IngredientName.From(ingredient.Name),
+            Units = ingredient.IngredientUnits
+                .OrderBy(iu => iu.UnitId)
+                .Select(iu => new ViewModel.IngredientUnit(
+                    IngredientUnitName.From(iu.Unit.Name),
+                    iu.Unit.Abbreviation is not null ? IngredientUnitAbbreviation.From(iu.Unit.Abbreviation) : null,
+                    IngredientUnitType.From(iu.Unit.UnitType.Name))),
         };
     }
 }

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -59,7 +59,7 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
 
         if (existingIngredients.Count != 0)
         {
-            throw new BusinessValidationException(
+            throw new ConflictException(
                 $"Ingredient '{newIngredient.Name.Value}' already exists with a different unit set.");
         }
 

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -43,6 +43,20 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
             .ConfigureAwait(false);
     }
 
+    public async Task<bool> RecipeNameExistsAsync(RecipeName name)
+    {
+        return await db.Recipes
+            .AnyAsync(r => r.Name == name.Value)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<bool> RecipeNameExistsAsync(RecipeName name, RecipeId excludedRecipeId)
+    {
+        return await db.Recipes
+            .AnyAsync(r => r.Name == name.Value && r.Id != excludedRecipeId.Value)
+            .ConfigureAwait(false);
+    }
+
     public async Task<RecipeId> CreateRecipeAsync(RecipeName name)
     {
         var entity = new RecipeEntity { Name = name.Value };
@@ -55,7 +69,7 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
     {
         ArgumentNullException.ThrowIfNull(recipeIngredients);
 
-        var incoming = recipeIngredients.ToList();
+        var incoming = recipeIngredients.Distinct().ToList();
         var incomingKeys = incoming
             .Select(i => new { IngredientName = i.IngredientName.Value, UnitName = i.UnitName.Value })
             .ToHashSet();

--- a/backend/MenuApi/Services/IngredientService.cs
+++ b/backend/MenuApi/Services/IngredientService.cs
@@ -14,7 +14,15 @@ public class IngredientService(IUnitRepository unitRepository, IIngredientReposi
 
     public async Task<Ingredient> CreateIngredientAsync(NewIngredient newIngredient)
     {
-        return await ingredientRepository.CreateIngredientAsync(newIngredient).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(newIngredient);
+
+        var normalizedIngredient = new NewIngredient
+        {
+            Name = newIngredient.Name,
+            UnitIds = [.. newIngredient.UnitIds.Distinct()],
+        };
+
+        return await ingredientRepository.CreateIngredientAsync(normalizedIngredient).ConfigureAwait(false);
     }
 }
 

--- a/backend/MenuApi/Services/RecipeService.cs
+++ b/backend/MenuApi/Services/RecipeService.cs
@@ -1,4 +1,5 @@
-﻿using MenuDB;
+using MenuDB;
+using MenuApi.Exceptions;
 using MenuApi.MappingProfiles;
 using MenuApi.Repositories;
 using MenuApi.ValueObjects;
@@ -39,7 +40,12 @@ public class RecipeService(IRecipeRepository recipeRepository, MenuDbContext db)
     {
         ArgumentNullException.ThrowIfNull(newRecipe);
 
-        var ingredients = ViewModelMapper.Map(newRecipe.Ingredients);
+        if (await recipeRepository.RecipeNameExistsAsync(newRecipe.Name).ConfigureAwait(false))
+        {
+            throw new ConflictException($"Recipe '{newRecipe.Name.Value}' already exists.");
+        }
+
+        var ingredients = NormalizeRecipeIngredients(newRecipe.Ingredients);
 
         var strategy = db.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
@@ -56,7 +62,12 @@ public class RecipeService(IRecipeRepository recipeRepository, MenuDbContext db)
     {
         ArgumentNullException.ThrowIfNull(newRecipe);
 
-        var ingredients = ViewModelMapper.Map(newRecipe.Ingredients);
+        if (await recipeRepository.RecipeNameExistsAsync(newRecipe.Name, recipeId).ConfigureAwait(false))
+        {
+            throw new ConflictException($"Recipe '{newRecipe.Name.Value}' already exists.");
+        }
+
+        var ingredients = NormalizeRecipeIngredients(newRecipe.Ingredients);
 
         var strategy = db.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
@@ -66,5 +77,32 @@ public class RecipeService(IRecipeRepository recipeRepository, MenuDbContext db)
             await recipeRepository.UpsertRecipeIngredientsAsync(recipeId, ingredients).ConfigureAwait(false);
             await tran.CommitAsync().ConfigureAwait(false);
         }).ConfigureAwait(false);
+    }
+
+    private static IReadOnlyList<DBModel.RecipeIngredient> NormalizeRecipeIngredients(IEnumerable<ViewModel.RecipeIngredient> recipeIngredients)
+    {
+        ArgumentNullException.ThrowIfNull(recipeIngredients);
+
+        var mappedIngredients = ViewModelMapper.Map(recipeIngredients).ToList();
+        var conflictingDuplicates = mappedIngredients
+            .GroupBy(ingredient => new
+            {
+                IngredientName = ingredient.IngredientName.Value,
+                UnitName = ingredient.UnitName.Value,
+            })
+            .Where(group => group.Select(ingredient => ingredient.Amount.Value).Distinct().Count() > 1)
+            .Select(group =>
+                $"Ingredient '{group.Key.IngredientName}' with unit '{group.Key.UnitName}' is specified multiple times with different amounts.")
+            .ToArray();
+
+        if (conflictingDuplicates.Length != 0)
+        {
+            throw new RequestValidationException(new Dictionary<string, string[]>
+            {
+                ["ingredients"] = conflictingDuplicates,
+            });
+        }
+
+        return [.. mappedIngredients.Distinct()];
     }
 }

--- a/backend/MenuDB/MenuDbContext.cs
+++ b/backend/MenuDB/MenuDbContext.cs
@@ -20,6 +20,7 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).UseIdentityColumn();
             e.Property(x => x.Name).HasColumnType("varchar(500)").IsRequired();
+            e.HasIndex(x => x.Name).IsUnique();
         });
 
         modelBuilder.Entity<IngredientEntity>(e =>
@@ -28,6 +29,7 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).UseIdentityColumn();
             e.Property(x => x.Name).HasColumnType("varchar(50)").IsRequired();
+            e.HasIndex(x => x.Name).IsUnique();
         });
 
         modelBuilder.Entity<UnitTypeEntity>(e =>

--- a/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.Designer.cs
+++ b/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.Designer.cs
@@ -3,6 +3,7 @@ using MenuDB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MenuDB.Migrations
 {
     [DbContext(typeof(MenuDbContext))]
-    partial class MenuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503213945_AddBusinessUniqueIndexes")]
+    partial class AddBusinessUniqueIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.cs
+++ b/backend/MenuDB/Migrations/20260503213945_AddBusinessUniqueIndexes.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MenuDB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBusinessUniqueIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                IF EXISTS (
+                    SELECT [Name]
+                    FROM [Recipe]
+                    GROUP BY [Name]
+                    HAVING COUNT(*) > 1
+                )
+                BEGIN
+                    THROW 50000, 'Cannot apply AddBusinessUniqueIndexes while duplicate Recipe.Name rows exist. Remediate duplicate recipe names before retrying the migration.', 1;
+                END;
+                """);
+
+            migrationBuilder.Sql(
+                """
+                IF EXISTS (
+                    SELECT [Name]
+                    FROM [Ingredient]
+                    GROUP BY [Name]
+                    HAVING COUNT(*) > 1
+                )
+                BEGIN
+                    THROW 50000, 'Cannot apply AddBusinessUniqueIndexes while duplicate Ingredient.Name rows exist. Remediate duplicate ingredient names before retrying the migration.', 1;
+                END;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recipe_Name",
+                table: "Recipe",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ingredient_Name",
+                table: "Ingredient",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Recipe_Name",
+                table: "Recipe");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Ingredient_Name",
+                table: "Ingredient");
+        }
+    }
+}

--- a/docs/specs/backend-write-duplicate-risk-audit.md
+++ b/docs/specs/backend-write-duplicate-risk-audit.md
@@ -89,6 +89,39 @@ This audit inventories every backend write endpoint under `backend/MenuApi/Recip
 5. `NewRecipeValidator` and `RecipeIngredientValidator` validate shape and value ranges, but they do not reject duplicate `(ingredient, unit)` pairs in the same request.
 6. The repository write paths rely on database primary keys to reject duplicate join-table rows instead of preventing duplicate attempts earlier.
 
+## Schema Hardening and Remediation Plan (2026-05-03T21:56:25.759+01:00)
+
+### Unique indexes to add
+
+- `Ingredient.Name` — canonical ingredient rows are now reused in the application layer, so the database can enforce one stored definition per ingredient name.
+- `Recipe.Name` — recipe names are business-significant and must be unique before the API can expose duplicate conflicts cleanly.
+
+### Pre-migration duplicate audit queries
+
+Run these checks before applying the uniqueness migration to any existing environment:
+
+```sql
+SELECT [Name], COUNT(*) AS [Count]
+FROM [Ingredient]
+GROUP BY [Name]
+HAVING COUNT(*) > 1;
+
+SELECT [Name], COUNT(*) AS [Count]
+FROM [Recipe]
+GROUP BY [Name]
+HAVING COUNT(*) > 1;
+```
+
+### Remediation steps if duplicates exist
+
+1. **Ingredient duplicates:** choose the canonical row to keep per duplicated name, update any `RecipeIngredient` references to point to that retained ingredient row, delete orphaned `IngredientUnit` links for removed rows, then delete the duplicate `Ingredient` rows.
+2. **Recipe duplicates:** choose the retained recipe record per duplicated name and either rename, merge, or remove the extras according to product intent before the uniqueness migration is retried.
+3. Re-run the duplicate audit queries until they return zero rows, then apply the migration.
+
+### Deployment note
+
+`Recipe.Name` uniqueness is intended to pair with issue #980's explicit conflict handling so duplicate recipe writes surface as controlled API responses rather than raw database failures.
+
 ## Duplicate-Handling Policy Buckets
 
 > **Note:** The sections below describe **target / intended** behaviour, not the current runtime behaviour described above. The current write paths do not yet implement these policies.


### PR DESCRIPTION
## Summary
- add duplicate-specific problem-details handlers for 409 conflict and 400 validation responses
- return explicit conflicts for recipe-name collisions and canonical ingredient redefinitions while keeping equivalent duplicates idempotent
- reject conflicting duplicate recipe ingredient amounts in one payload and cover the new contract with unit and integration tests

## Testing
- dotnet test --project .\backend\MenuApi.Tests\MenuApi.Tests.csproj
- dotnet test --project .\backend\MenuApi.Integration.Tests\MenuApi.Integration.Tests.csproj

## Notes
- This branch is stacked after the open duplicate-prevention PRs in this epic and should be reviewed after #1055.

Closes #980