### PR TITLE
feat: prevent duplicate inserts for canonical/reference rows (#978)

### DIFF
--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -100,6 +100,38 @@ public class IngredientIntegrationTests
         units.Should().ContainSingle(u => u.Name == "Grams");
     }
 
+    [Theory, AutoData]
+    public async Task Create_Ingredient_With_Same_Name_Twice_Returns_Same_Id([StringLength(50, MinimumLength = 1)] string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var (firstId, _, _) = await PostIngredientAsync(client, ingredientName, [4]);
+        var (secondId, _, _) = await PostIngredientAsync(client, ingredientName, [1]);
+
+        secondId.Should().Be(firstId);
+
+        using var listResponse = await client.GetAsync("/api/ingredient");
+        await listResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        var data = await listResponse.Content.ReadAsStringAsync();
+        var ingredients = JsonSerializer.Deserialize<List<Ingredient>>(data, jsonOptions);
+        ingredients.Should().NotBeNull();
+        ingredients!.Count(i => i.Name == ingredientName).Should().Be(1);
+    }
+
+    [Theory, AutoData]
+    public async Task Create_Ingredient_With_Different_Case_Returns_Same_Id([StringLength(50, MinimumLength = 1)] string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+        var upperName = ingredientName.ToUpperInvariant();
+        var lowerName = ingredientName.ToLowerInvariant();
+
+        var (firstId, _, _) = await PostIngredientAsync(client, upperName, [4]);
+        var (secondId, _, _) = await PostIngredientAsync(client, lowerName, [1]);
+
+        secondId.Should().Be(firstId);
+    }
+
     internal async Task<(int Id, string Name, List<IngredientUnit> Units)> PostIngredientAsync(
         HttpClient client, string name, List<int> unitIds)
     {

--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -12,6 +12,8 @@ namespace MenuApi.Integration.Tests;
 [Collection("API Host Collection")]
 public class IngredientIntegrationTests
 {
+    private const string IngredientEndpoint = "/api/ingredient";
+
     private readonly JsonSerializerOptions jsonOptions;
     private readonly ApiTestFixture fixture;
 
@@ -28,7 +30,7 @@ public class IngredientIntegrationTests
     public async Task Get_Ingredients_Returns_Ok()
     {
         using var client = await fixture.GetHttpClient();
-        using var response = await client.GetAsync("/api/ingredient");
+        using var response = await client.GetAsync(IngredientEndpoint);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
 
@@ -78,7 +80,7 @@ public class IngredientIntegrationTests
 
         var (createdId, _, _) = await PostIngredientAsync(client, ingredientName, [3]);
 
-        using var response = await client.GetAsync("/api/ingredient");
+        using var response = await client.GetAsync(IngredientEndpoint);
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         var data = await response.Content.ReadAsStringAsync();
@@ -110,7 +112,7 @@ public class IngredientIntegrationTests
 
         secondId.Should().Be(firstId);
 
-        using var listResponse = await client.GetAsync("/api/ingredient");
+        using var listResponse = await client.GetAsync(IngredientEndpoint);
         await listResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         var data = await listResponse.Content.ReadAsStringAsync();
@@ -137,7 +139,7 @@ public class IngredientIntegrationTests
     {
         var body = new NewIngredient { Name = name, UnitIds = unitIds };
         var requestContent = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
-        using var response = await client.PostAsync("/api/ingredient", requestContent);
+        using var response = await client.PostAsync(IngredientEndpoint, requestContent);
 
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
 

--- a/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/IngredientIntegrationTests.cs
@@ -118,15 +118,18 @@ public class IngredientIntegrationTests
         var data = await listResponse.Content.ReadAsStringAsync();
         var ingredients = JsonSerializer.Deserialize<List<Ingredient>>(data, jsonOptions);
         ingredients.Should().NotBeNull();
-        ingredients!.Count(i => i.Name == ingredientName).Should().Be(1);
+        ingredients!.Count(i => string.Equals(i.Name, ingredientName, StringComparison.OrdinalIgnoreCase)).Should().Be(1);
     }
 
     [Theory, AutoData]
-    public async Task Create_Ingredient_With_Different_Case_Returns_Same_Id([StringLength(50, MinimumLength = 1)] string ingredientName)
+    public async Task Create_Ingredient_With_Different_Case_Returns_Same_Id([StringLength(49, MinimumLength = 1)] string ingredientName)
     {
         using var client = await fixture.GetHttpClient();
-        var upperName = ingredientName.ToUpperInvariant();
-        var lowerName = ingredientName.ToLowerInvariant();
+
+        // Prepend "X" to guarantee at least one cased letter so upper/lower are always distinct
+        var baseName = "X" + ingredientName;
+        var upperName = baseName.ToUpperInvariant();
+        var lowerName = baseName.ToLowerInvariant();
 
         var (firstId, _, _) = await PostIngredientAsync(client, upperName, [4]);
         var (secondId, _, _) = await PostIngredientAsync(client, lowerName, [1]);

--- a/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
@@ -66,6 +66,32 @@ public class IngredientRepositoryTests
         count.Should().Be(1);
     }
 
+    [Fact]
+    public async Task CreateIngredientAsync_Returns_Existing_Ingredient_When_Name_Already_Exists_Even_With_Unknown_UnitId()
+    {
+        // UnitIds are only used when inserting a new row. When the canonical row already exists,
+        // the provided UnitIds are intentionally ignored — the existing ingredient is returned as-is.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedUnitsAsync(db, cancellationToken);
+
+        var sut = new IngredientRepository(db);
+        var first = await sut.CreateIngredientAsync(new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [4],
+        });
+
+        var second = await sut.CreateIngredientAsync(new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [9999], // non-existent unit ID — ignored because ingredient already exists
+        });
+
+        second.Id.Should().Be(first.Id);
+        second.Units.Should().ContainSingle(u => u.Name == IngredientUnitName.From("Grams"));
+    }
+
     private static MenuDbContext CreateDbContext()
     {
         var options = new DbContextOptionsBuilder<MenuDbContext>()

--- a/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/IngredientRepositoryTests.cs
@@ -1,0 +1,88 @@
+using AwesomeAssertions;
+using MenuDB;
+using MenuDB.Data;
+using MenuApi.Repositories;
+using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MenuApi.Tests.Repositories;
+
+public class IngredientRepositoryTests
+{
+    [Fact]
+    public async Task CreateIngredientAsync_Creates_New_Ingredient_When_Name_Does_Not_Exist()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedUnitsAsync(db, cancellationToken);
+        var sut = new IngredientRepository(db);
+
+        var result = await sut.CreateIngredientAsync(new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [4],
+        });
+
+        result.Id.Value.Should().BeGreaterThan(0);
+        result.Name.Should().Be(IngredientName.From("Sugar"));
+        result.Units.Should().ContainSingle(u => u.Name == IngredientUnitName.From("Grams"));
+
+        var count = await db.Ingredients.CountAsync(cancellationToken);
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateIngredientAsync_Returns_Existing_Ingredient_When_Name_Already_Exists()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        await SeedUnitsAsync(db, cancellationToken);
+
+        var unitType = new UnitTypeEntity { Id = 99, Name = "Other" };
+        var otherUnit = new UnitEntity { Id = 99, Name = "Cup", UnitTypeId = 99, UnitType = unitType };
+        db.UnitTypes.Add(unitType);
+        db.Units.Add(otherUnit);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var sut = new IngredientRepository(db);
+        var first = await sut.CreateIngredientAsync(new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [4],
+        });
+
+        var second = await sut.CreateIngredientAsync(new NewIngredient
+        {
+            Name = IngredientName.From("Sugar"),
+            UnitIds = [99],
+        });
+
+        second.Id.Should().Be(first.Id);
+        second.Units.Should().ContainSingle(u => u.Name == IngredientUnitName.From("Grams"));
+
+        var count = await db.Ingredients.CountAsync(i => i.Name == "Sugar", cancellationToken);
+        count.Should().Be(1);
+    }
+
+    private static MenuDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+
+    private static async Task SeedUnitsAsync(MenuDbContext db, CancellationToken cancellationToken)
+    {
+        var unitType = new UnitTypeEntity { Id = 3, Name = "Weight" };
+        var unit = new UnitEntity { Id = 4, Name = "Grams", UnitTypeId = 3, UnitType = unitType };
+
+        db.UnitTypes.Add(unitType);
+        db.Units.Add(unit);
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -39,6 +39,36 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
     {
         ArgumentNullException.ThrowIfNull(newIngredient);
 
+        var existing = await db.Ingredients
+            .Where(i => i.Name == newIngredient.Name.Value)
+            .OrderBy(i => i.Id)
+            .Select(i => new
+            {
+                i.Id,
+                i.Name,
+                Units = i.IngredientUnits.Select(iu => new
+                {
+                    iu.Unit.Name,
+                    iu.Unit.Abbreviation,
+                    UnitType = iu.Unit.UnitType.Name,
+                })
+            })
+            .FirstOrDefaultAsync()
+            .ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            return new ViewModel.Ingredient
+            {
+                Id = IngredientId.From(existing.Id),
+                Name = IngredientName.From(existing.Name),
+                Units = existing.Units.Select(u => new ViewModel.IngredientUnit(
+                    IngredientUnitName.From(u.Name),
+                    u.Abbreviation is not null ? IngredientUnitAbbreviation.From(u.Abbreviation) : null,
+                    IngredientUnitType.From(u.UnitType))),
+            };
+        }
+
         var unitIds = newIngredient.UnitIds.Distinct().ToList();
 
         var entity = new IngredientEntity

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -10,29 +10,14 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
     public async Task<IEnumerable<ViewModel.Ingredient>> GetIngredientsAsync()
     {
         var rows = await db.Ingredients
-            .Select(i => new
-            {
+            .Select(i => new IngredientProjection(
                 i.Id,
                 i.Name,
-                Units = i.IngredientUnits.Select(iu => new
-                {
-                    iu.Unit.Name,
-                    iu.Unit.Abbreviation,
-                    UnitType = iu.Unit.UnitType.Name,
-                })
-            })
+                i.IngredientUnits.Select(iu => new UnitProjection(iu.Unit.Name, iu.Unit.Abbreviation, iu.Unit.UnitType.Name))))
             .ToListAsync()
             .ConfigureAwait(false);
 
-        return rows.Select(i => new ViewModel.Ingredient
-        {
-            Id = IngredientId.From(i.Id),
-            Name = IngredientName.From(i.Name),
-            Units = i.Units.Select(u => new ViewModel.IngredientUnit(
-                IngredientUnitName.From(u.Name),
-                u.Abbreviation is not null ? IngredientUnitAbbreviation.From(u.Abbreviation) : null,
-                IngredientUnitType.From(u.UnitType))),
-        });
+        return rows.Select(MapToViewModel);
     }
 
     public async Task<ViewModel.Ingredient> CreateIngredientAsync(ViewModel.NewIngredient newIngredient)
@@ -42,31 +27,16 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
         var existing = await db.Ingredients
             .Where(i => i.Name == newIngredient.Name.Value)
             .OrderBy(i => i.Id)
-            .Select(i => new
-            {
+            .Select(i => new IngredientProjection(
                 i.Id,
                 i.Name,
-                Units = i.IngredientUnits.Select(iu => new
-                {
-                    iu.Unit.Name,
-                    iu.Unit.Abbreviation,
-                    UnitType = iu.Unit.UnitType.Name,
-                })
-            })
+                i.IngredientUnits.Select(iu => new UnitProjection(iu.Unit.Name, iu.Unit.Abbreviation, iu.Unit.UnitType.Name))))
             .FirstOrDefaultAsync()
             .ConfigureAwait(false);
 
         if (existing is not null)
         {
-            return new ViewModel.Ingredient
-            {
-                Id = IngredientId.From(existing.Id),
-                Name = IngredientName.From(existing.Name),
-                Units = existing.Units.Select(u => new ViewModel.IngredientUnit(
-                    IngredientUnitName.From(u.Name),
-                    u.Abbreviation is not null ? IngredientUnitAbbreviation.From(u.Abbreviation) : null,
-                    IngredientUnitType.From(u.UnitType))),
-            };
+            return MapToViewModel(existing);
         }
 
         var unitIds = newIngredient.UnitIds.Distinct().ToList();
@@ -83,28 +53,28 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
 
         var created = await db.Ingredients
             .Where(i => i.Id == entity.Id)
-            .Select(i => new
-            {
+            .Select(i => new IngredientProjection(
                 i.Id,
                 i.Name,
-                Units = i.IngredientUnits.Select(iu => new
-                {
-                    iu.Unit.Name,
-                    iu.Unit.Abbreviation,
-                    UnitType = iu.Unit.UnitType.Name,
-                })
-            })
+                i.IngredientUnits.Select(iu => new UnitProjection(iu.Unit.Name, iu.Unit.Abbreviation, iu.Unit.UnitType.Name))))
             .FirstAsync()
             .ConfigureAwait(false);
 
-        return new ViewModel.Ingredient
+        return MapToViewModel(created);
+    }
+
+    private static ViewModel.Ingredient MapToViewModel(IngredientProjection p) =>
+        new()
         {
-            Id = IngredientId.From(created.Id),
-            Name = IngredientName.From(created.Name),
-            Units = created.Units.Select(u => new ViewModel.IngredientUnit(
+            Id = IngredientId.From(p.Id),
+            Name = IngredientName.From(p.Name),
+            Units = p.Units.Select(u => new ViewModel.IngredientUnit(
                 IngredientUnitName.From(u.Name),
                 u.Abbreviation is not null ? IngredientUnitAbbreviation.From(u.Abbreviation) : null,
                 IngredientUnitType.From(u.UnitType))),
         };
-    }
+
+    private sealed record IngredientProjection(int Id, string Name, IEnumerable<UnitProjection> Units);
+
+    private sealed record UnitProjection(string Name, string? Abbreviation, string UnitType);
 }


### PR DESCRIPTION
## Summary

Implements lookup-before-insert (get-or-create) for \Ingredient\, the only canonical/reference entity with a mutable API write path.

Fixes #978

## Changes

### \IngredientRepository.CreateIngredientAsync\
Before inserting, queries for an existing ingredient with the same name. If found, the existing row is returned instead of inserting a duplicate (client-transparent — caller still gets 200 OK with the ingredient). \OrderBy(Id)\ ensures deterministic selection in case legacy duplicates exist.

SQL Server's default CI collation means the \WHERE Name = value\ lookup is case-insensitive, so \'Sugar'\ and \'sugar'\ are treated as the same canonical row.

### Tests
- **Unit tests** (\IngredientRepositoryTests\): new file covering new-row creation and same-name reuse with in-memory DB.
- **Integration tests** (\IngredientIntegrationTests\): two new tests — same name twice returns the same ID; mixed-case names return the same ID (exercising SQL Server CI collation end-to-end).

## Decisions
- Name is the canonical identity key for \Ingredient\; units are associations, not part of identity.
- Client receives the existing ingredient as-is (no unit merging, no 409 conflict).
- Concurrency/race conditions are out of scope (noted in #887; addressed by the unique constraint in #979).