### PR TITLE
Add missing uniqueness constraints for Recipe, Ingredient, Unit, and UnitType

### DIFF
--- a/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -139,6 +139,32 @@ public class RecipeIntegrationTests
         await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
     }
 
+    [Theory, AutoData]
+    public async Task Update_Recipe_To_Duplicate_Name_Returns_UnprocessableEntity(
+        [NoAutoProperties] NewRecipe recipe1,
+        [StringLength(500, MinimumLength = 1)] string recipeName1,
+        [NoAutoProperties] NewRecipe recipe2,
+        [StringLength(500, MinimumLength = 1)] string recipeName2,
+        [StringLength(50, MinimumLength = 1)] string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+        recipe1.Name = recipeName1;
+        recipe1.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }];
+        recipe2.Name = recipeName2;
+        recipe2.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 200 }];
+
+        await PostRecipeAsync(client, recipe1);
+        var (id2, _) = await PostRecipeAsync(client, recipe2);
+
+        // Try to rename recipe2 to recipe1's name - should be 422
+        recipe2.Name = recipeName1;
+        using var requestContent = new StringContent(JsonSerializer.Serialize(recipe2), Encoding.UTF8, "application/json");
+        using var response = await client.PutAsync($"/api/recipe/{id2}", requestContent);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+    }
+
     private static async Task PostIngredientAsync(HttpClient client, string name)
     {
         var body = new { name, unitIds = new[] { 4 } }; // Grams

--- a/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -120,6 +120,25 @@ public class RecipeIntegrationTests
         ingredients![0].Name.Should().Be(ingredientName);
     }
 
+    [Theory, AutoData]
+    public async Task Create_Recipe_With_Duplicate_Name_Returns_UnprocessableEntity(
+        [NoAutoProperties] NewRecipe recipe,
+        [StringLength(500, MinimumLength = 1)] string recipeName,
+        [StringLength(50, MinimumLength = 1)] string ingredientName)
+    {
+        using var client = await fixture.GetHttpClient();
+        await PostIngredientAsync(client, ingredientName);
+        recipe.Name = recipeName;
+        recipe.Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = Grams, Amount = 100 }];
+
+        await PostRecipeAsync(client, recipe);
+
+        using var requestContent = new StringContent(JsonSerializer.Serialize(recipe), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", requestContent);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+    }
+
     private static async Task PostIngredientAsync(HttpClient client, string name)
     {
         var body = new { name, unitIds = new[] { 4 } }; // Grams

--- a/backend/MenuApi/Exceptions/DbUpdateExceptionExtensions.cs
+++ b/backend/MenuApi/Exceptions/DbUpdateExceptionExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace MenuApi.Exceptions;
+
+public static class DbUpdateExceptionExtensions
+{
+    private const int SqlServerUniqueConstraintViolationError = 2627;
+    private const int SqlServerUniqueIndexViolationError = 2601;
+
+    public static bool IsUniqueConstraintViolation(this DbUpdateException exception)
+    {
+        return exception.InnerException is SqlException sqlEx &&
+               (sqlEx.Number == SqlServerUniqueConstraintViolationError ||
+                sqlEx.Number == SqlServerUniqueIndexViolationError);
+    }
+}

--- a/backend/MenuApi/Exceptions/DbUpdateExceptionExtensions.cs
+++ b/backend/MenuApi/Exceptions/DbUpdateExceptionExtensions.cs
@@ -14,4 +14,10 @@ public static class DbUpdateExceptionExtensions
                (sqlEx.Number == SqlServerUniqueConstraintViolationError ||
                 sqlEx.Number == SqlServerUniqueIndexViolationError);
     }
+
+    public static bool IsUniqueConstraintViolation(this SqlException exception)
+    {
+        return exception.Number == SqlServerUniqueConstraintViolationError ||
+               exception.Number == SqlServerUniqueIndexViolationError;
+    }
 }

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -56,6 +56,14 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
         }
         catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
         {
+            // Detach the failed entities so EF doesn't retry the insert.
+            foreach (var unit in entity.IngredientUnits)
+            {
+                db.Entry(unit).State = EntityState.Detached;
+            }
+
+            db.Entry(entity).State = EntityState.Detached;
+
             // Race condition: another request inserted the same name between our read and write.
             // Re-query and return the now-existing ingredient.
             var racedExisting = await db.Ingredients

--- a/backend/MenuApi/Repositories/IngredientRepository.cs
+++ b/backend/MenuApi/Repositories/IngredientRepository.cs
@@ -1,5 +1,6 @@
 ﻿﻿using MenuDB;
 using MenuDB.Data;
+using MenuApi.Exceptions;
 using MenuApi.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 
@@ -49,7 +50,25 @@ public class IngredientRepository(MenuDbContext db) : IIngredientRepository
                 .ToList(),
         };
         db.Ingredients.Add(entity);
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        try
+        {
+            await db.SaveChangesAsync().ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
+        {
+            // Race condition: another request inserted the same name between our read and write.
+            // Re-query and return the now-existing ingredient.
+            var racedExisting = await db.Ingredients
+                .Where(i => i.Name == newIngredient.Name.Value)
+                .OrderBy(i => i.Id)
+                .Select(i => new IngredientProjection(
+                    i.Id,
+                    i.Name,
+                    i.IngredientUnits.Select(iu => new UnitProjection(iu.Unit.Name, iu.Unit.Abbreviation, iu.Unit.UnitType.Name))))
+                .FirstAsync()
+                .ConfigureAwait(false);
+            return MapToViewModel(racedExisting);
+        }
 
         var created = await db.Ingredients
             .Where(i => i.Id == entity.Id)

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -122,9 +122,16 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
 
     public async Task UpdateRecipeAsync(RecipeId recipeId, RecipeName name)
     {
-        await db.Recipes
-            .Where(r => r.Id == recipeId.Value)
-            .ExecuteUpdateAsync(s => s.SetProperty(r => r.Name, name.Value))
-            .ConfigureAwait(false);
+        try
+        {
+            await db.Recipes
+                .Where(r => r.Id == recipeId.Value)
+                .ExecuteUpdateAsync(s => s.SetProperty(r => r.Name, name.Value))
+                .ConfigureAwait(false);
+        }
+        catch (Microsoft.Data.SqlClient.SqlException ex) when (ex.Number == 2627 || ex.Number == 2601)
+        {
+            throw new BusinessValidationException($"A recipe named '{name.Value}' already exists.");
+        }
     }
 }

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -4,6 +4,7 @@ using MenuDB.Data;
 using MenuApi.DBModel;
 using MenuApi.Exceptions;
 using MenuApi.ValueObjects;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
 namespace MenuApi.Repositories;
@@ -129,7 +130,7 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
                 .ExecuteUpdateAsync(s => s.SetProperty(r => r.Name, name.Value))
                 .ConfigureAwait(false);
         }
-        catch (Microsoft.Data.SqlClient.SqlException ex) when (ex.Number == 2627 || ex.Number == 2601)
+        catch (SqlException ex) when (ex.IsUniqueConstraintViolation())
         {
             throw new BusinessValidationException($"A recipe named '{name.Value}' already exists.");
         }

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -47,7 +47,15 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
     {
         var entity = new RecipeEntity { Name = name.Value };
         db.Recipes.Add(entity);
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        try
+        {
+            await db.SaveChangesAsync().ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
+        {
+            throw new BusinessValidationException($"A recipe named '{name.Value}' already exists.");
+        }
+
         return RecipeId.From(entity.Id);
     }
 

--- a/backend/MenuDB/MenuDbContext.cs
+++ b/backend/MenuDB/MenuDbContext.cs
@@ -20,6 +20,7 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).UseIdentityColumn();
             e.Property(x => x.Name).HasColumnType("varchar(500)").IsRequired();
+            e.HasIndex(x => x.Name).IsUnique().HasDatabaseName("UX_Recipe_Name");
         });
 
         modelBuilder.Entity<IngredientEntity>(e =>
@@ -28,6 +29,7 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).UseIdentityColumn();
             e.Property(x => x.Name).HasColumnType("varchar(50)").IsRequired();
+            e.HasIndex(x => x.Name).IsUnique().HasDatabaseName("UX_Ingredient_Name");
         });
 
         modelBuilder.Entity<UnitTypeEntity>(e =>
@@ -36,6 +38,7 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).ValueGeneratedNever();
             e.Property(x => x.Name).HasColumnType("varchar(50)").IsRequired();
+            e.HasIndex(x => x.Name).IsUnique().HasDatabaseName("UX_UnitType_Name");
             e.HasData(
                 new UnitTypeEntity { Id = 1, Name = "Volume" },
                 new UnitTypeEntity { Id = 2, Name = "Quantity" },
@@ -49,6 +52,8 @@ public class MenuDbContext(DbContextOptions<MenuDbContext> options) : DbContext(
             e.Property(x => x.Id).ValueGeneratedNever();
             e.Property(x => x.Name).HasColumnType("varchar(50)").IsRequired();
             e.Property(x => x.Abbreviation).HasColumnType("varchar(5)");
+            e.HasIndex(x => x.Name).IsUnique().HasDatabaseName("UX_Unit_Name");
+            e.HasIndex(x => x.Abbreviation).IsUnique().HasDatabaseName("UX_Unit_Abbreviation").HasFilter("[Abbreviation] IS NOT NULL");
             e.HasOne(x => x.UnitType)
              .WithMany(x => x.Units)
              .HasForeignKey(x => x.UnitTypeId)

--- a/backend/MenuDB/Migrations/20260522201428_AddUniqueNameConstraints.Designer.cs
+++ b/backend/MenuDB/Migrations/20260522201428_AddUniqueNameConstraints.Designer.cs
@@ -3,6 +3,7 @@ using MenuDB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MenuDB.Migrations
 {
     [DbContext(typeof(MenuDbContext))]
-    partial class MenuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522201428_AddUniqueNameConstraints")]
+    partial class AddUniqueNameConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/MenuDB/Migrations/20260522201428_AddUniqueNameConstraints.cs
+++ b/backend/MenuDB/Migrations/20260522201428_AddUniqueNameConstraints.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MenuDB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUniqueNameConstraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "UX_UnitType_Name",
+                table: "UnitType",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Unit_Abbreviation",
+                table: "Unit",
+                column: "Abbreviation",
+                unique: true,
+                filter: "[Abbreviation] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Unit_Name",
+                table: "Unit",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Recipe_Name",
+                table: "Recipe",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Ingredient_Name",
+                table: "Ingredient",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_UnitType_Name",
+                table: "UnitType");
+
+            migrationBuilder.DropIndex(
+                name: "UX_Unit_Abbreviation",
+                table: "Unit");
+
+            migrationBuilder.DropIndex(
+                name: "UX_Unit_Name",
+                table: "Unit");
+
+            migrationBuilder.DropIndex(
+                name: "UX_Recipe_Name",
+                table: "Recipe");
+
+            migrationBuilder.DropIndex(
+                name: "UX_Ingredient_Name",
+                table: "Ingredient");
+        }
+    }
+}

--- a/backend/MenuDB/Migrations/20260522201428_AddUniqueNameConstraints.cs
+++ b/backend/MenuDB/Migrations/20260522201428_AddUniqueNameConstraints.cs
@@ -29,11 +29,33 @@ namespace MenuDB.Migrations
                 column: "Name",
                 unique: true);
 
+            migrationBuilder.Sql(@"
+                IF EXISTS (
+                    SELECT Name FROM Recipe
+                    GROUP BY Name
+                    HAVING COUNT(*) > 1
+                )
+                BEGIN
+                    THROW 51000, 'Duplicate Recipe names exist. Deduplicate Recipe rows before running this migration.', 1;
+                END
+            ");
+
             migrationBuilder.CreateIndex(
                 name: "UX_Recipe_Name",
                 table: "Recipe",
                 column: "Name",
                 unique: true);
+
+            migrationBuilder.Sql(@"
+                IF EXISTS (
+                    SELECT Name FROM Ingredient
+                    GROUP BY Name
+                    HAVING COUNT(*) > 1
+                )
+                BEGIN
+                    THROW 51000, 'Duplicate Ingredient names exist. Deduplicate Ingredient rows before running this migration.', 1;
+                END
+            ");
 
             migrationBuilder.CreateIndex(
                 name: "UX_Ingredient_Name",


### PR DESCRIPTION
## Summary

Hardens the database schema by adding unique constraints where business uniqueness is confirmed but was previously unenforced.

## Changes

### New unique indexes (migration: `AddUniqueNameConstraints`)

| Table | Column | Index Name | Notes |
|---|---|---|---|
| `Recipe` | `Name` | `UX_Recipe_Name` | |
| `Ingredient` | `Name` | `UX_Ingredient_Name` | |
| `UnitType` | `Name` | `UX_UnitType_Name` | Seeded reference data - zero migration risk |
| `Unit` | `Name` | `UX_Unit_Name` | Seeded reference data - zero migration risk |
| `Unit` | `Abbreviation` | `UX_Unit_Abbreviation` | Filtered index (`WHERE NOT NULL`); seeded data - zero migration risk |

### Application-layer violation handling

- Added `DbUpdateExceptionExtensions.IsUniqueConstraintViolation()` helpers (SQL Server error codes 2627/2601) for both `DbUpdateException` and `SqlException`
- `RecipeRepository.CreateRecipeAsync` catches unique constraint violations and surfaces them as `BusinessValidationException` -> **422 Unprocessable Entity**
- `RecipeRepository.UpdateRecipeAsync` catches unique constraint violations and surfaces them as `BusinessValidationException` -> **422 Unprocessable Entity**
- `IngredientRepository.CreateIngredientAsync` uses a lookup-before-insert (idempotent) pattern from PR #978: duplicate ingredient creation returns **200 OK** with the existing ingredient. A race-condition catch block detaches the failed entity and re-queries to return the existing row cleanly.

### Integration tests

- Duplicate `Recipe.Name` creation -> 422
- Duplicate `Recipe.Name` on update (PUT) -> 422

## Migration risk

- `Recipe.Name` / `Ingredient.Name`: If any pre-existing rows share a name the migration will fail. A pre-flight `THROW` guard is included in the migration script to fail early with a clear, actionable message rather than an opaque SQL error.
- `UnitType`, `Unit.Name`, `Unit.Abbreviation`: Seeded reference data with no duplicate risk.
