### PR TITLE
fix: replace setup-node pnpm cache with explicit actions/cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,8 +210,19 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: 'pnpm'
-          cache-dependency-path: ui/menu-website/pnpm-lock.yaml
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+        working-directory: ./ui/menu-website
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('ui/menu-website/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,13 +203,13 @@ jobs:
           path: open-api
           merge-multiple: true
 
-      - name: Enable pnpm with corepack
-        run: corepack enable pnpm
-
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
+
+      - name: Enable pnpm with corepack
+        run: corepack enable pnpm
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -220,7 +220,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('ui/menu-website/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('ui/menu-website/pnpm-lock.yaml', 'ui/menu-website/package.json') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 


### PR DESCRIPTION
## Problem

The \Frontend validation\ CI job was failing on the \Post Use Node.js 22.x\ step with:

\\\
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
\\\

This happens because \ctions/setup-node@v6\ with \cache: 'pnpm'\ computes the pnpm store path at **setup time** (before \pnpm install\ has run). When pnpm is managed by corepack and the cache misses, the store directory doesn't yet exist on disk at that point. The POST step's path-validation then fails and marks the entire job as failed — even though all tests, lint, and build steps passed.

Seen in: https://github.com/dgee2/Menu/actions/runs/26310091099/job/77456532434?pr=1058

## Fix

- Remove \cache: 'pnpm'\ from \setup-node@v6\ so it no longer manages pnpm caching
- Add a **Get pnpm store directory** step that runs \pnpm store path --silent\ after corepack is enabled, capturing the real store path used by the project's pinned pnpm version
- Add an explicit \ctions/cache@v5\ step keyed on \pnpm-lock.yaml\ to cache that path

The explicit cache step avoids the path-detection race condition and is the approach recommended by the pnpm docs for corepack-managed pnpm.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>