### PR TITLE
fix: replace actions/setup-copilot with npm install for Copilot CLI

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -85,7 +85,7 @@ jobs:
         run: corepack enable pnpm
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot
+        run: npm install -g --ignore-scripts @github/copilot@1.0.51
 
       - name: Create or update dependency PRs with Copilot
         env:

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -85,7 +85,7 @@ jobs:
         run: corepack enable pnpm
 
       - name: Install Copilot CLI
-        run: npm install -g --ignore-scripts @github/copilot@1.0.51
+        run: npm install -g --ignore-scripts @github/copilot@1
 
       - name: Create or update dependency PRs with Copilot
         env:

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -84,8 +84,8 @@ jobs:
       - name: Enable pnpm via Corepack
         run: corepack enable pnpm
 
-      - name: Setup Copilot CLI
-        uses: actions/setup-copilot@v0.0.5
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
 
       - name: Create or update dependency PRs with Copilot
         env:
@@ -103,7 +103,7 @@ jobs:
           PROMPT_GHA_DISCOVERY_SCOPE: actions and reusable workflows
           PROMPT_PRERELEASE_POLICY: Consider prerelease versions only when the current version is prerelease; otherwise prefer stable releases.
         run: |
-          cat > /tmp/copilot-prompt.txt <<EOF
+          cat > "$RUNNER_TEMP/copilot-prompt.txt" <<EOF
           Read ".github/prompts/dependency-update.prompt.md" and apply these repository skills:
           - ${PROMPT_ECOSYSTEM_SKILL}
           - dependency-update-pr-description
@@ -128,4 +128,4 @@ jobs:
             --enable-all-github-mcp-tools \
             --autopilot \
             --no-ask-user \
-            -p "$(cat /tmp/copilot-prompt.txt)"
+            -p "$(cat "$RUNNER_TEMP/copilot-prompt.txt")"


### PR DESCRIPTION
## Problem

The \Dependency updates (copilot)\ workflow has been failing on every run since it was created with:

\\\
##[error]Unable to resolve action \ctions/setup-copilot\, not found
\\\

\ctions/setup-copilot\ is not a real GitHub Action. This caused every matrix job to fail during the action-resolution phase before any step executed.

## Fix

Replace:
\\\yaml
- name: Setup Copilot CLI
  uses: actions/setup-copilot@v0.0.5
\\\

with the correct installation method per the [GitHub docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/automate-with-actions):
\\\yaml
- name: Install Copilot CLI
  run: npm install -g @github/copilot
\\\

The \ctions/setup-node@v6\ step already present in the job ensures Node.js is available before this install runs.

Also replaces the hardcoded \/tmp\ temp file path with \\\, which is the portable GitHub Actions convention.

## Related

Closes #1010 (follow-up fix to PRs #1011 and #1026)