### PR TITLE
Expose explicit conflict when same ingredient+unit appears with different amounts

### DIFF
--- a/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeWithIngredientsIntegrationTests.cs
@@ -235,6 +235,71 @@ public class RecipeWithIngredientsIntegrationTests
         returnedIngredients[0].Amount.Should().Be(125m);
     }
 
+    [Theory, AutoData]
+    public async Task Create_Recipe_With_Conflicting_Ingredient_Amounts_Returns_UnprocessableEntity(
+        [StringLength(50, MinimumLength = 1)] string ingredientName,
+        [StringLength(500, MinimumLength = 1)] string recipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var newRecipe = new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 200m },
+            ]
+        };
+
+        using var content = new StringContent(JsonSerializer.Serialize(newRecipe, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(responseBody);
+        doc.RootElement.GetProperty("status").GetInt32().Should().Be(422);
+    }
+
+    [Theory, AutoData]
+    public async Task Update_Recipe_With_Conflicting_Ingredient_Amounts_Returns_UnprocessableEntity(
+        [StringLength(50, MinimumLength = 1)] string ingredientName,
+        [StringLength(500, MinimumLength = 1)] string recipeName,
+        [StringLength(500, MinimumLength = 1)] string updatedRecipeName)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        await PostIngredientAsync(client, ingredientName, [4]);
+
+        var (recipeId, _, _) = await PostRecipeAsync(client, new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients = [new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m }]
+        });
+
+        var updateBody = new NewRecipe
+        {
+            Name = updatedRecipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 100m },
+                new RecipeIngredient { Name = ingredientName, Unit = "Grams", Amount = 200m },
+            ]
+        };
+
+        using var content = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PutAsync($"/api/recipe/{recipeId}", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(responseBody);
+        doc.RootElement.GetProperty("status").GetInt32().Should().Be(422);
+    }
+
     private async Task PostIngredientAsync(HttpClient client, string name, List<int> unitIds)
     {
         var body = new NewIngredient { Name = name, UnitIds = unitIds };

--- a/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using FakeItEasy;
 using MenuDB;
+using MenuApi.Exceptions;
 using MenuApi.Repositories;
 using MenuApi.Services;
 using MenuApi.ValueObjects;
@@ -188,5 +189,83 @@ public class RecipeServiceTests
 
         var result = await fun.Should().ThrowAsync<ArgumentNullException>();
         result.And.ParamName.Should().Be("newRecipe");
+    }
+
+    [Fact]
+    public async Task CreateRecipeAsync_Throws_BusinessValidationException_When_Same_IngredientUnit_Has_Conflicting_Amounts()
+    {
+        var recipeName = RecipeName.From("Cake");
+
+        await sut.Invoking(s => s.CreateRecipeAsync(new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(100m) },
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(200m) },
+            ],
+        })).Should().ThrowAsync<BusinessValidationException>();
+
+        A.CallTo(() => recipeRepository.CreateRecipeAsync(A<RecipeName>._)).MustNotHaveHappened();
+        A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(A<RecipeId>._, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UpdateRecipeAsync_Throws_BusinessValidationException_When_Same_IngredientUnit_Has_Conflicting_Amounts()
+    {
+        var recipeId = RecipeId.From(1);
+        var recipeName = RecipeName.From("Cake");
+
+        await sut.Invoking(s => s.UpdateRecipeAsync(recipeId, new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(100m) },
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(200m) },
+            ],
+        })).Should().ThrowAsync<BusinessValidationException>();
+
+        A.CallTo(() => recipeRepository.UpdateRecipeAsync(A<RecipeId>._, A<RecipeName>._)).MustNotHaveHappened();
+        A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(A<RecipeId>._, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task CreateRecipeAsync_Reports_All_Conflicting_IngredientUnit_Pairs()
+    {
+        var recipeName = RecipeName.From("Cake");
+
+        var ex = await sut.Invoking(s => s.CreateRecipeAsync(new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(100m) },
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(200m) },
+                new RecipeIngredient { Name = IngredientName.From("Flour"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(300m) },
+                new RecipeIngredient { Name = IngredientName.From("Flour"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(400m) },
+            ],
+        })).Should().ThrowAsync<BusinessValidationException>();
+
+        ex.And.Message.Should().Contain("Sugar");
+        ex.And.Message.Should().Contain("Flour");
+    }
+
+    [Fact]
+    public async Task CreateRecipeAsync_Exact_Duplicate_Then_Conflicting_Detects_Conflict()
+    {
+        // Three entries: two exact duplicates (silently absorbed) + one with different amount = conflict
+        var recipeName = RecipeName.From("Cake");
+
+        await sut.Invoking(s => s.CreateRecipeAsync(new NewRecipe
+        {
+            Name = recipeName,
+            Ingredients =
+            [
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(100m) },
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(100m) },
+                new RecipeIngredient { Name = IngredientName.From("Sugar"), Unit = IngredientUnitName.From("Grams"), Amount = IngredientAmount.From(200m) },
+            ],
+        })).Should().ThrowAsync<BusinessValidationException>();
     }
 }

--- a/backend/MenuApi/Services/RecipeService.cs
+++ b/backend/MenuApi/Services/RecipeService.cs
@@ -1,4 +1,5 @@
 using MenuDB;
+using MenuApi.Exceptions;
 using MenuApi.MappingProfiles;
 using MenuApi.Repositories;
 using MenuApi.ValueObjects;
@@ -71,6 +72,23 @@ public class RecipeService(IRecipeRepository recipeRepository, MenuDbContext db)
     private static IReadOnlyList<DBModel.RecipeIngredient> NormalizeRecipeIngredients(IEnumerable<ViewModel.RecipeIngredient> recipeIngredients)
     {
         ArgumentNullException.ThrowIfNull(recipeIngredients);
-        return [.. ViewModelMapper.Map(recipeIngredients).Distinct()];
+
+        var deduped = ViewModelMapper.Map(recipeIngredients).Distinct().ToList();
+
+        // After exact-duplicate removal, any (IngredientName, UnitName) group with more than one
+        // entry represents the same ingredient+unit with conflicting amounts — a business conflict.
+        var conflicts = deduped
+            .GroupBy(i => (i.IngredientName, i.UnitName))
+            .Where(g => g.Count() > 1)
+            .Select(g => $"'{g.Key.IngredientName.Value}' with unit '{g.Key.UnitName.Value}'")
+            .ToList();
+
+        if (conflicts.Count > 0)
+        {
+            throw new BusinessValidationException(
+                $"The following ingredients appear more than once with conflicting amounts: {string.Join(", ", conflicts)}.");
+        }
+
+        return deduped;
     }
 }


### PR DESCRIPTION
## Why

When a recipe request contained the same ingredient+unit combination more than once with different amounts, the API would crash with HTTP 500. `NormalizeRecipeIngredients` used `Distinct()` (structural equality on all three fields: ingredient name, unit, and amount), so exact duplicates were silently absorbed, but entries that differed only in amount both passed through. Both then entered `UpsertRecipeIngredientsAsync`, where each attempted to insert a row with the same composite primary key `(RecipeId, IngredientId, UnitId)`, causing an unhandled `DbUpdateException` and a 500 response.

This is a business-significant conflict: a recipe listing the same ingredient and unit twice with contradictory amounts is logically invalid, and the user must resolve the ambiguity before the request can succeed.

## What changed

`RecipeService.NormalizeRecipeIngredients` now performs conflict detection after the existing `Distinct()` deduplication pass. Any `(IngredientName, UnitName)` group that still has more than one entry (meaning the same ingredient+unit with different amounts) triggers a `BusinessValidationException` that names all conflicting pairs. `BusinessValidationExceptionHandler` converts this to HTTP 422, which both recipe endpoints already advertise in their OpenAPI contract.

The ordering matters: exact duplicates are still silently absorbed first (behaviour from #977), then the conflict check runs over what remains. No repository, schema, or OpenAPI contract changes are required.

## Tests

- **Unit tests (4 new):** verify that `CreateRecipeAsync` and `UpdateRecipeAsync` throw `BusinessValidationException` and make no repository write calls when conflicting amounts are present; verify that all conflicting pairs are reported in the message; verify that mixed exact-duplicate + conflicting-amount input is still detected as a conflict.
- **Integration tests (2 new):** verify that `POST /recipe` and `PUT /recipe/{id}` return HTTP 422 with a problem detail when the same ingredient+unit appears with different amounts.

Fixes: #980