### PR TITLE
Update Microsoft.ApplicationInsights.AspNetCore from 3.1.1 to 3.1.2

### DIFF
--- a/backend/MenuApi/MenuApi.csproj
+++ b/backend/MenuApi/MenuApi.csproj
@@ -37,7 +37,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.8">
 		  <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Dependency Update Summary

This pull request updates a single .NET/NuGet package with a simple version bump.

### Package Updated

- **Microsoft.ApplicationInsights.AspNetCore**: `3.1.1` → `3.1.2`

### Grouping Rationale

This is a **simple version bump** grouped into the `/simple` branch. Only project file version edits are required with no code changes, tool-driven updates, or breaking changes.

### Classification

**Simple version bump** — only the `MenuApi.csproj` file required a version number edit. No application code changes, configuration updates, or tool-driven migrations are needed.

### Best-Practice Changes

**No best-practice changes were introduced or suggested by this update.**

**Decision**: `do not implement now` — no new best-practice action is required for this patch-level update.

### Validation Results

All validation commands were executed successfully:

✅ **Backend restore**: `dotnet restore MenuApi.sln` — succeeded  
✅ **Backend build**: `dotnet build MenuApi.sln --configuration Release --no-restore` — succeeded  
✅ **Backend unit tests**: `dotnet test MenuApi.Tests/MenuApi.Tests.csproj --configuration Release --no-build` — **56/56 tests passed**  
⚠️ **Backend test infrastructure**: Test logger encountered GitHub Actions environment file issue (not related to dependency update)  
✅ **Frontend dependencies**: `pnpm install --frozen-lockfile` — succeeded  
✅ **OpenAPI generation**: `pnpm run generate-openapi` — succeeded  
✅ **Frontend lint**: `pnpm run lint` — succeeded  
✅ **Frontend build**: `pnpm run build` — succeeded  
⚠️ **Frontend tests**: `pnpm run test` — infrastructure issue (Playwright browsers cannot be installed in restricted container environment)

### Notes

- The backend test suite passed completely (56/56 tests succeeded). The test infrastructure error is related to GitHub Actions step summary file access and is not caused by this dependency update.
- The frontend test failure is due to missing Playwright browser binaries which cannot be installed in the current container due to privilege restrictions. This is a pre-existing infrastructure limitation, not a regression from this update.
- The core validation (build, lint, and all backend tests) passed successfully, confirming the update is safe.

### Prerelease Policy

This update follows the stable-only policy: the current version (3.1.1) is stable, so only stable releases were considered. Version 3.1.2 is the latest stable patch release.




> [!WARNING]
> <details>
> <summary>Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `169.254.169.254`
> - `rt.services.visualstudio.com`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "169.254.169.254"
>     - "rt.services.visualstudio.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Dependency Update Dotnet](https://github.com/dgee2/Menu/actions/runs/26631907189) · ● 7.7M · [◷](https://github.com/search?q=repo%3Adgee2%2FMenu+%22gh-aw-workflow-id%3A+dependency-update-dotnet%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Dependency Update Dotnet, engine: copilot, version: 1.0.48, model: claude-sonnet-4.5, id: 26631907189, workflow_id: dependency-update-dotnet, run: https://github.com/dgee2/Menu/actions/runs/26631907189 -->

<!-- gh-aw-workflow-id: dependency-update-dotnet -->