### PR TITLE
Implement user provisioning for authenticated API requests

### DIFF
--- a/backend/MenuApi.Integration.Tests/UserProvisioningIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/UserProvisioningIntegrationTests.cs
@@ -1,0 +1,60 @@
+using AwesomeAssertions;
+using MenuApi.Integration.Tests.Factory;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace MenuApi.Integration.Tests;
+
+[Collection("API Host Collection")]
+public class UserProvisioningIntegrationTests(ApiTestFixture fixture)
+{
+    [Fact]
+    public async Task First_Authenticated_Request_Returns_A_MenuUserId()
+    {
+        using var client = await fixture.GetHttpClient();
+
+        using var response = await client.GetAsync("/api/user/me");
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        var menuUserId = await response.Content.ReadFromJsonAsync<int>();
+        menuUserId.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Repeated_Authenticated_Requests_Return_Same_MenuUserId()
+    {
+        using var client1 = await fixture.GetHttpClient();
+        using var client2 = await fixture.GetHttpClient();
+
+        using var response1 = await client1.GetAsync("/api/user/me");
+        using var response2 = await client2.GetAsync("/api/user/me");
+
+        await response1.ShouldHaveStatusCode(HttpStatusCode.OK);
+        await response2.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        var id1 = await response1.Content.ReadFromJsonAsync<int>();
+        var id2 = await response2.Content.ReadFromJsonAsync<int>();
+
+        id1.Should().Be(id2);
+        id1.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Concurrent_Authenticated_Requests_All_Return_Same_MenuUserId()
+    {
+        var tasks = Enumerable.Range(0, 5).Select(async _ =>
+        {
+            using var client = await fixture.GetHttpClient();
+            using var response = await client.GetAsync("/api/user/me");
+            await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+            return await response.Content.ReadFromJsonAsync<int>();
+        });
+
+        var ids = await Task.WhenAll(tasks);
+
+        ids.Should().AllSatisfy(id => id.Should().BeGreaterThan(0));
+        ids.Distinct().Should().HaveCount(1);
+    }
+}

--- a/backend/MenuApi.Integration.Tests/UserProvisioningIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/UserProvisioningIntegrationTests.cs
@@ -2,6 +2,8 @@ using AwesomeAssertions;
 using MenuApi.Integration.Tests.Factory;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace MenuApi.Integration.Tests;
@@ -9,6 +11,11 @@ namespace MenuApi.Integration.Tests;
 [Collection("API Host Collection")]
 public class UserProvisioningIntegrationTests(ApiTestFixture fixture)
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     [Fact]
     public async Task First_Authenticated_Request_Returns_A_MenuUserId()
     {
@@ -18,8 +25,27 @@ public class UserProvisioningIntegrationTests(ApiTestFixture fixture)
 
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        var menuUserId = await response.Content.ReadFromJsonAsync<int>();
-        menuUserId.Should().BeGreaterThan(0);
+        var profile = await response.Content.ReadFromJsonAsync<UserProfileResponse>(JsonOptions);
+        profile.Should().NotBeNull();
+        profile!.Id.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Authenticated_Request_Stores_User_Data_In_Database()
+    {
+        using var client = await fixture.GetHttpClient();
+
+        using var response = await client.GetAsync("/api/user/me");
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        var profile = await response.Content.ReadFromJsonAsync<UserProfileResponse>(JsonOptions);
+        profile.Should().NotBeNull();
+        profile!.Id.Should().BeGreaterThan(0);
+        profile.AuthSubject.Should().NotBeNullOrWhiteSpace();
+        profile.DisplayName.Should().NotBeNullOrWhiteSpace();
+        profile.CreatedAtUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
+        profile.LastSeenAtUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
     }
 
     [Fact]
@@ -34,11 +60,12 @@ public class UserProvisioningIntegrationTests(ApiTestFixture fixture)
         await response1.ShouldHaveStatusCode(HttpStatusCode.OK);
         await response2.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        var id1 = await response1.Content.ReadFromJsonAsync<int>();
-        var id2 = await response2.Content.ReadFromJsonAsync<int>();
+        var profile1 = await response1.Content.ReadFromJsonAsync<UserProfileResponse>(JsonOptions);
+        var profile2 = await response2.Content.ReadFromJsonAsync<UserProfileResponse>(JsonOptions);
 
-        id1.Should().Be(id2);
-        id1.Should().BeGreaterThan(0);
+        profile1!.Id.Should().Be(profile2!.Id);
+        profile1.AuthSubject.Should().Be(profile2.AuthSubject);
+        profile1.Id.Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -49,12 +76,40 @@ public class UserProvisioningIntegrationTests(ApiTestFixture fixture)
             using var client = await fixture.GetHttpClient();
             using var response = await client.GetAsync("/api/user/me");
             await response.ShouldHaveStatusCode(HttpStatusCode.OK);
-            return await response.Content.ReadFromJsonAsync<int>();
+            return await response.Content.ReadFromJsonAsync<UserProfileResponse>(JsonOptions);
         });
 
-        var ids = await Task.WhenAll(tasks);
+        var profiles = await Task.WhenAll(tasks);
 
-        ids.Should().AllSatisfy(id => id.Should().BeGreaterThan(0));
-        ids.Distinct().Should().HaveCount(1);
+        profiles.Should().AllSatisfy(p =>
+        {
+            p.Should().NotBeNull();
+            p!.Id.Should().BeGreaterThan(0);
+        });
+        profiles.Select(p => p!.Id).Distinct().Should().HaveCount(1);
+    }
+
+    private sealed class UserProfileResponse
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("authSubject")]
+        public string AuthSubject { get; set; } = null!;
+
+        [JsonPropertyName("displayName")]
+        public string DisplayName { get; set; } = null!;
+
+        [JsonPropertyName("email")]
+        public string? Email { get; set; }
+
+        [JsonPropertyName("avatarUrl")]
+        public string? AvatarUrl { get; set; }
+
+        [JsonPropertyName("createdAtUtc")]
+        public DateTime CreatedAtUtc { get; set; }
+
+        [JsonPropertyName("lastSeenAtUtc")]
+        public DateTime LastSeenAtUtc { get; set; }
     }
 }

--- a/backend/MenuApi.Tests/Services/MenuUserServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/MenuUserServiceTests.cs
@@ -33,13 +33,13 @@ public class MenuUserServiceTests
     }
 
     [Fact]
-    public async Task ProvisionAsync_CallsRepository_WithNullOptionalFields()
+    public async Task ProvisionAsync_CallsRepository_WithNullDisplayNameAndOptionalFields()
     {
         var expected = MenuUserId.From(7);
-        A.CallTo(() => repository.UpsertAsync("auth0|456", "auth0|456", null, null))
+        A.CallTo(() => repository.UpsertAsync("auth0|456", null, null, null))
             .Returns(expected);
 
-        var result = await sut.ProvisionAsync("auth0|456", "auth0|456", null, null);
+        var result = await sut.ProvisionAsync("auth0|456", null, null, null);
 
         result.Should().Be(expected);
     }

--- a/backend/MenuApi.Tests/Services/MenuUserServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/MenuUserServiceTests.cs
@@ -1,0 +1,46 @@
+using AwesomeAssertions;
+using FakeItEasy;
+using MenuApi.Repositories;
+using MenuApi.Services;
+using MenuApi.ValueObjects;
+using Xunit;
+
+namespace MenuApi.Tests.Services;
+
+public class MenuUserServiceTests
+{
+    private readonly IMenuUserRepository repository;
+    private readonly MenuUserService sut;
+
+    public MenuUserServiceTests()
+    {
+        repository = A.Fake<IMenuUserRepository>();
+        sut = new MenuUserService(repository);
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_CallsRepository_WithCorrectArguments()
+    {
+        var expected = MenuUserId.From(42);
+        A.CallTo(() => repository.UpsertAsync("auth0|123", "Alice", "alice@example.com", "https://example.com/pic.png"))
+            .Returns(expected);
+
+        var result = await sut.ProvisionAsync("auth0|123", "Alice", "alice@example.com", "https://example.com/pic.png");
+
+        result.Should().Be(expected);
+        A.CallTo(() => repository.UpsertAsync("auth0|123", "Alice", "alice@example.com", "https://example.com/pic.png"))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_CallsRepository_WithNullOptionalFields()
+    {
+        var expected = MenuUserId.From(7);
+        A.CallTo(() => repository.UpsertAsync("auth0|456", "auth0|456", null, null))
+            .Returns(expected);
+
+        var result = await sut.ProvisionAsync("auth0|456", "auth0|456", null, null);
+
+        result.Should().Be(expected);
+    }
+}

--- a/backend/MenuApi/Middleware/UserProvisioningMiddleware.cs
+++ b/backend/MenuApi/Middleware/UserProvisioningMiddleware.cs
@@ -15,14 +15,17 @@ public class UserProvisioningMiddleware(RequestDelegate next)
     {
         if (context.User.Identity?.IsAuthenticated == true)
         {
-            var authSubject = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var authSubject = Truncate(context.User.FindFirstValue(ClaimTypes.NameIdentifier), 256);
 
             if (authSubject is not null)
             {
-                var displayName = context.User.FindFirstValue("name") ?? authSubject;
-                var email = context.User.FindFirstValue(ClaimTypes.Email)
-                    ?? context.User.FindFirstValue("email");
-                var avatarUrl = context.User.FindFirstValue("picture");
+                // Pass null when the claim is absent so the repository does not
+                // overwrite existing profile data with a missing claim value.
+                var displayName = Truncate(context.User.FindFirstValue("name"), 100);
+                var email = Truncate(
+                    context.User.FindFirstValue(ClaimTypes.Email) ?? context.User.FindFirstValue("email"),
+                    256);
+                var avatarUrl = Truncate(context.User.FindFirstValue("picture"), 512);
 
                 var menuUserId = await menuUserService
                     .ProvisionAsync(authSubject, displayName, email, avatarUrl)
@@ -34,4 +37,7 @@ public class UserProvisioningMiddleware(RequestDelegate next)
 
         await next(context).ConfigureAwait(false);
     }
+
+    private static string? Truncate(string? value, int maxLength) =>
+        value is null || value.Length <= maxLength ? value : value[..maxLength];
 }

--- a/backend/MenuApi/Middleware/UserProvisioningMiddleware.cs
+++ b/backend/MenuApi/Middleware/UserProvisioningMiddleware.cs
@@ -1,0 +1,37 @@
+using System.Security.Claims;
+using MenuApi.Services;
+using MenuApi.ValueObjects;
+
+namespace MenuApi.Middleware;
+
+public static class MenuUserHttpContextKeys
+{
+    public const string MenuUserId = "MenuUserId";
+}
+
+public class UserProvisioningMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context, IMenuUserService menuUserService)
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var authSubject = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (authSubject is not null)
+            {
+                var displayName = context.User.FindFirstValue("name") ?? authSubject;
+                var email = context.User.FindFirstValue(ClaimTypes.Email)
+                    ?? context.User.FindFirstValue("email");
+                var avatarUrl = context.User.FindFirstValue("picture");
+
+                var menuUserId = await menuUserService
+                    .ProvisionAsync(authSubject, displayName, email, avatarUrl)
+                    .ConfigureAwait(false);
+
+                context.Items[MenuUserHttpContextKeys.MenuUserId] = menuUserId;
+            }
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+}

--- a/backend/MenuApi/Program.cs
+++ b/backend/MenuApi/Program.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using MenuDB;
 using MenuApi;
 using MenuApi.Exceptions;
+using MenuApi.Middleware;
 using MenuApi.Recipes;
 using MenuApi.Repositories;
 using MenuApi.Services;
@@ -22,6 +23,9 @@ builder.Services.AddTransient<IIngredientService, IngredientService>();
 
 builder.Services.AddTransient<IRecipeRepository, RecipeRepository>();
 builder.Services.AddTransient<IRecipeService, RecipeService>();
+
+builder.Services.AddTransient<IMenuUserRepository, MenuUserRepository>();
+builder.Services.AddTransient<IMenuUserService, MenuUserService>();
 
 builder.Services.AddExceptionHandler<BusinessValidationExceptionHandler>();
 
@@ -59,6 +63,7 @@ app.UseCors("AllowAll");
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<UserProvisioningMiddleware>();
 
 app.MapDefaultApiEndpoints();
 
@@ -68,6 +73,7 @@ var api = app.MapGroup("/api")
 
 api.MapRecipes();
 api.MapIngredients();
+api.MapUsers();
 
 await app.RunAsync();
 

--- a/backend/MenuApi/Recipes/UserApi.cs
+++ b/backend/MenuApi/Recipes/UserApi.cs
@@ -1,5 +1,7 @@
 using MenuApi.Middleware;
+using MenuApi.Services;
 using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
 
 namespace MenuApi.Recipes;
 
@@ -12,19 +14,21 @@ public static class UserApi
         group.WithTags("Users");
 
         group.MapGet("/me", GetCurrentUserAsync)
-            .Produces<int>(StatusCodes.Status200OK)
+            .Produces<UserProfile>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized);
 
         return group;
     }
 
-    private static IResult GetCurrentUserAsync(HttpContext httpContext)
+    private static async Task<IResult> GetCurrentUserAsync(HttpContext httpContext, IMenuUserService menuUserService)
     {
-        if (httpContext.Items[MenuUserHttpContextKeys.MenuUserId] is MenuUserId menuUserId)
+        if (httpContext.Items[MenuUserHttpContextKeys.MenuUserId] is not MenuUserId menuUserId)
         {
-            return Results.Ok(menuUserId.Value);
+            return Results.Unauthorized();
         }
 
-        return Results.Unauthorized();
+        var profile = await menuUserService.GetCurrentUserAsync(menuUserId).ConfigureAwait(false);
+
+        return profile is not null ? Results.Ok(profile) : Results.Unauthorized();
     }
 }

--- a/backend/MenuApi/Recipes/UserApi.cs
+++ b/backend/MenuApi/Recipes/UserApi.cs
@@ -1,0 +1,30 @@
+using MenuApi.Middleware;
+using MenuApi.ValueObjects;
+
+namespace MenuApi.Recipes;
+
+public static class UserApi
+{
+    public static RouteGroupBuilder MapUsers(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/user");
+
+        group.WithTags("Users");
+
+        group.MapGet("/me", GetCurrentUserAsync)
+            .Produces<int>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    private static IResult GetCurrentUserAsync(HttpContext httpContext)
+    {
+        if (httpContext.Items[MenuUserHttpContextKeys.MenuUserId] is MenuUserId menuUserId)
+        {
+            return Results.Ok(menuUserId.Value);
+        }
+
+        return Results.Unauthorized();
+    }
+}

--- a/backend/MenuApi/Repositories/IMenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/IMenuUserRepository.cs
@@ -1,0 +1,8 @@
+using MenuApi.ValueObjects;
+
+namespace MenuApi.Repositories;
+
+public interface IMenuUserRepository
+{
+    Task<MenuUserId> UpsertAsync(string authSubject, string displayName, string? email, string? avatarUrl);
+}

--- a/backend/MenuApi/Repositories/IMenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/IMenuUserRepository.cs
@@ -4,5 +4,5 @@ namespace MenuApi.Repositories;
 
 public interface IMenuUserRepository
 {
-    Task<MenuUserId> UpsertAsync(string authSubject, string displayName, string? email, string? avatarUrl);
+    Task<MenuUserId> UpsertAsync(string authSubject, string? displayName, string? email, string? avatarUrl);
 }

--- a/backend/MenuApi/Repositories/IMenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/IMenuUserRepository.cs
@@ -1,8 +1,11 @@
 using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
 
 namespace MenuApi.Repositories;
 
 public interface IMenuUserRepository
 {
     Task<MenuUserId> UpsertAsync(string authSubject, string? displayName, string? email, string? avatarUrl);
+
+    Task<UserProfile?> GetAsync(MenuUserId menuUserId);
 }

--- a/backend/MenuApi/Repositories/MenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/MenuUserRepository.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using MenuDB;
 using MenuDB.Data;
 using MenuApi.Exceptions;
@@ -7,7 +6,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MenuApi.Repositories;
 
-[ExcludeFromCodeCoverage]
 public class MenuUserRepository(MenuDbContext db) : IMenuUserRepository
 {
     public async Task<MenuUserId> UpsertAsync(string authSubject, string displayName, string? email, string? avatarUrl)

--- a/backend/MenuApi/Repositories/MenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/MenuUserRepository.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics.CodeAnalysis;
+using MenuDB;
+using MenuDB.Data;
+using MenuApi.Exceptions;
+using MenuApi.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+
+namespace MenuApi.Repositories;
+
+[ExcludeFromCodeCoverage]
+public class MenuUserRepository(MenuDbContext db) : IMenuUserRepository
+{
+    public async Task<MenuUserId> UpsertAsync(string authSubject, string displayName, string? email, string? avatarUrl)
+    {
+        var now = DateTime.UtcNow;
+
+        var updated = await db.MenuUsers
+            .Where(u => u.AuthSubject == authSubject)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(u => u.DisplayName, displayName)
+                .SetProperty(u => u.Email, email)
+                .SetProperty(u => u.AvatarUrl, avatarUrl)
+                .SetProperty(u => u.LastSeenAtUtc, now))
+            .ConfigureAwait(false);
+
+        if (updated > 0)
+        {
+            var existingId = await db.MenuUsers
+                .Where(u => u.AuthSubject == authSubject)
+                .Select(u => u.Id)
+                .FirstAsync()
+                .ConfigureAwait(false);
+
+            return MenuUserId.From(existingId);
+        }
+
+        var entity = new MenuUserEntity
+        {
+            AuthSubject = authSubject,
+            DisplayName = displayName,
+            Email = email,
+            AvatarUrl = avatarUrl,
+            CreatedAtUtc = now,
+            LastSeenAtUtc = now,
+        };
+
+        db.MenuUsers.Add(entity);
+
+        try
+        {
+            await db.SaveChangesAsync().ConfigureAwait(false);
+            return MenuUserId.From(entity.Id);
+        }
+        catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
+        {
+            db.Entry(entity).State = EntityState.Detached;
+
+            await db.MenuUsers
+                .Where(u => u.AuthSubject == authSubject)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(u => u.DisplayName, displayName)
+                    .SetProperty(u => u.Email, email)
+                    .SetProperty(u => u.AvatarUrl, avatarUrl)
+                    .SetProperty(u => u.LastSeenAtUtc, now))
+                .ConfigureAwait(false);
+
+            var concurrentId = await db.MenuUsers
+                .Where(u => u.AuthSubject == authSubject)
+                .Select(u => u.Id)
+                .FirstAsync()
+                .ConfigureAwait(false);
+
+            return MenuUserId.From(concurrentId);
+        }
+    }
+}

--- a/backend/MenuApi/Repositories/MenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/MenuUserRepository.cs
@@ -2,6 +2,7 @@ using MenuDB;
 using MenuDB.Data;
 using MenuApi.Exceptions;
 using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
 using Microsoft.EntityFrameworkCore;
 
 namespace MenuApi.Repositories;
@@ -76,5 +77,23 @@ public class MenuUserRepository(MenuDbContext db) : IMenuUserRepository
         {
             user.AvatarUrl = avatarUrl;
         }
+    }
+
+    public async Task<UserProfile?> GetAsync(MenuUserId menuUserId)
+    {
+        return await db.MenuUsers
+            .Where(u => u.Id == menuUserId.Value)
+            .Select(u => new UserProfile
+            {
+                Id = MenuUserId.From(u.Id),
+                AuthSubject = u.AuthSubject,
+                DisplayName = u.DisplayName,
+                Email = u.Email,
+                AvatarUrl = u.AvatarUrl,
+                CreatedAtUtc = u.CreatedAtUtc,
+                LastSeenAtUtc = u.LastSeenAtUtc,
+            })
+            .FirstOrDefaultAsync()
+            .ConfigureAwait(false);
     }
 }

--- a/backend/MenuApi/Repositories/MenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/MenuUserRepository.cs
@@ -13,15 +13,24 @@ public class MenuUserRepository(MenuDbContext db) : IMenuUserRepository
     {
         var now = DateTime.UtcNow;
 
-        var existing = await db.MenuUsers
-            .FirstOrDefaultAsync(u => u.AuthSubject == authSubject)
+        var updated = await db.MenuUsers
+            .Where(u => u.AuthSubject == authSubject)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(u => u.DisplayName, u => displayName ?? u.DisplayName)
+                .SetProperty(u => u.Email, u => email ?? u.Email)
+                .SetProperty(u => u.AvatarUrl, u => avatarUrl ?? u.AvatarUrl)
+                .SetProperty(u => u.LastSeenAtUtc, now))
             .ConfigureAwait(false);
 
-        if (existing is not null)
+        if (updated > 0)
         {
-            ApplyProfileUpdates(existing, displayName, email, avatarUrl, now);
-            await db.SaveChangesAsync().ConfigureAwait(false);
-            return MenuUserId.From(existing.Id);
+            var existingId = await db.MenuUsers
+                .Where(u => u.AuthSubject == authSubject)
+                .Select(u => u.Id)
+                .FirstAsync()
+                .ConfigureAwait(false);
+
+            return MenuUserId.From(existingId);
         }
 
         var entity = new MenuUserEntity
@@ -45,37 +54,22 @@ public class MenuUserRepository(MenuDbContext db) : IMenuUserRepository
         {
             db.Entry(entity).State = EntityState.Detached;
 
-            var concurrent = await db.MenuUsers
-                .FirstAsync(u => u.AuthSubject == authSubject)
+            await db.MenuUsers
+                .Where(u => u.AuthSubject == authSubject)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(u => u.DisplayName, u => displayName ?? u.DisplayName)
+                    .SetProperty(u => u.Email, u => email ?? u.Email)
+                    .SetProperty(u => u.AvatarUrl, u => avatarUrl ?? u.AvatarUrl)
+                    .SetProperty(u => u.LastSeenAtUtc, now))
                 .ConfigureAwait(false);
 
-            ApplyProfileUpdates(concurrent, displayName, email, avatarUrl, now);
-            await db.SaveChangesAsync().ConfigureAwait(false);
-            return MenuUserId.From(concurrent.Id);
-        }
-    }
+            var concurrentId = await db.MenuUsers
+                .Where(u => u.AuthSubject == authSubject)
+                .Select(u => u.Id)
+                .FirstAsync()
+                .ConfigureAwait(false);
 
-    private static void ApplyProfileUpdates(
-        MenuUserEntity user,
-        string? displayName,
-        string? email,
-        string? avatarUrl,
-        DateTime now)
-    {
-        user.LastSeenAtUtc = now;
-        if (displayName is not null)
-        {
-            user.DisplayName = displayName;
-        }
-
-        if (email is not null)
-        {
-            user.Email = email;
-        }
-
-        if (avatarUrl is not null)
-        {
-            user.AvatarUrl = avatarUrl;
+            return MenuUserId.From(concurrentId);
         }
     }
 

--- a/backend/MenuApi/Repositories/MenuUserRepository.cs
+++ b/backend/MenuApi/Repositories/MenuUserRepository.cs
@@ -8,34 +8,25 @@ namespace MenuApi.Repositories;
 
 public class MenuUserRepository(MenuDbContext db) : IMenuUserRepository
 {
-    public async Task<MenuUserId> UpsertAsync(string authSubject, string displayName, string? email, string? avatarUrl)
+    public async Task<MenuUserId> UpsertAsync(string authSubject, string? displayName, string? email, string? avatarUrl)
     {
         var now = DateTime.UtcNow;
 
-        var updated = await db.MenuUsers
-            .Where(u => u.AuthSubject == authSubject)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(u => u.DisplayName, displayName)
-                .SetProperty(u => u.Email, email)
-                .SetProperty(u => u.AvatarUrl, avatarUrl)
-                .SetProperty(u => u.LastSeenAtUtc, now))
+        var existing = await db.MenuUsers
+            .FirstOrDefaultAsync(u => u.AuthSubject == authSubject)
             .ConfigureAwait(false);
 
-        if (updated > 0)
+        if (existing is not null)
         {
-            var existingId = await db.MenuUsers
-                .Where(u => u.AuthSubject == authSubject)
-                .Select(u => u.Id)
-                .FirstAsync()
-                .ConfigureAwait(false);
-
-            return MenuUserId.From(existingId);
+            ApplyProfileUpdates(existing, displayName, email, avatarUrl, now);
+            await db.SaveChangesAsync().ConfigureAwait(false);
+            return MenuUserId.From(existing.Id);
         }
 
         var entity = new MenuUserEntity
         {
             AuthSubject = authSubject,
-            DisplayName = displayName,
+            DisplayName = displayName ?? authSubject,
             Email = email,
             AvatarUrl = avatarUrl,
             CreatedAtUtc = now,
@@ -53,22 +44,37 @@ public class MenuUserRepository(MenuDbContext db) : IMenuUserRepository
         {
             db.Entry(entity).State = EntityState.Detached;
 
-            await db.MenuUsers
-                .Where(u => u.AuthSubject == authSubject)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(u => u.DisplayName, displayName)
-                    .SetProperty(u => u.Email, email)
-                    .SetProperty(u => u.AvatarUrl, avatarUrl)
-                    .SetProperty(u => u.LastSeenAtUtc, now))
+            var concurrent = await db.MenuUsers
+                .FirstAsync(u => u.AuthSubject == authSubject)
                 .ConfigureAwait(false);
 
-            var concurrentId = await db.MenuUsers
-                .Where(u => u.AuthSubject == authSubject)
-                .Select(u => u.Id)
-                .FirstAsync()
-                .ConfigureAwait(false);
+            ApplyProfileUpdates(concurrent, displayName, email, avatarUrl, now);
+            await db.SaveChangesAsync().ConfigureAwait(false);
+            return MenuUserId.From(concurrent.Id);
+        }
+    }
 
-            return MenuUserId.From(concurrentId);
+    private static void ApplyProfileUpdates(
+        MenuUserEntity user,
+        string? displayName,
+        string? email,
+        string? avatarUrl,
+        DateTime now)
+    {
+        user.LastSeenAtUtc = now;
+        if (displayName is not null)
+        {
+            user.DisplayName = displayName;
+        }
+
+        if (email is not null)
+        {
+            user.Email = email;
+        }
+
+        if (avatarUrl is not null)
+        {
+            user.AvatarUrl = avatarUrl;
         }
     }
 }

--- a/backend/MenuApi/Services/IMenuUserService.cs
+++ b/backend/MenuApi/Services/IMenuUserService.cs
@@ -1,8 +1,11 @@
 using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
 
 namespace MenuApi.Services;
 
 public interface IMenuUserService
 {
     Task<MenuUserId> ProvisionAsync(string authSubject, string? displayName, string? email, string? avatarUrl);
+
+    Task<UserProfile?> GetCurrentUserAsync(MenuUserId menuUserId);
 }

--- a/backend/MenuApi/Services/IMenuUserService.cs
+++ b/backend/MenuApi/Services/IMenuUserService.cs
@@ -1,0 +1,8 @@
+using MenuApi.ValueObjects;
+
+namespace MenuApi.Services;
+
+public interface IMenuUserService
+{
+    Task<MenuUserId> ProvisionAsync(string authSubject, string displayName, string? email, string? avatarUrl);
+}

--- a/backend/MenuApi/Services/IMenuUserService.cs
+++ b/backend/MenuApi/Services/IMenuUserService.cs
@@ -4,5 +4,5 @@ namespace MenuApi.Services;
 
 public interface IMenuUserService
 {
-    Task<MenuUserId> ProvisionAsync(string authSubject, string displayName, string? email, string? avatarUrl);
+    Task<MenuUserId> ProvisionAsync(string authSubject, string? displayName, string? email, string? avatarUrl);
 }

--- a/backend/MenuApi/Services/MenuUserService.cs
+++ b/backend/MenuApi/Services/MenuUserService.cs
@@ -1,5 +1,6 @@
 using MenuApi.Repositories;
 using MenuApi.ValueObjects;
+using MenuApi.ViewModel;
 
 namespace MenuApi.Services;
 
@@ -8,5 +9,10 @@ public class MenuUserService(IMenuUserRepository menuUserRepository) : IMenuUser
     public async Task<MenuUserId> ProvisionAsync(string authSubject, string? displayName, string? email, string? avatarUrl)
     {
         return await menuUserRepository.UpsertAsync(authSubject, displayName, email, avatarUrl).ConfigureAwait(false);
+    }
+
+    public async Task<UserProfile?> GetCurrentUserAsync(MenuUserId menuUserId)
+    {
+        return await menuUserRepository.GetAsync(menuUserId).ConfigureAwait(false);
     }
 }

--- a/backend/MenuApi/Services/MenuUserService.cs
+++ b/backend/MenuApi/Services/MenuUserService.cs
@@ -5,7 +5,7 @@ namespace MenuApi.Services;
 
 public class MenuUserService(IMenuUserRepository menuUserRepository) : IMenuUserService
 {
-    public async Task<MenuUserId> ProvisionAsync(string authSubject, string displayName, string? email, string? avatarUrl)
+    public async Task<MenuUserId> ProvisionAsync(string authSubject, string? displayName, string? email, string? avatarUrl)
     {
         return await menuUserRepository.UpsertAsync(authSubject, displayName, email, avatarUrl).ConfigureAwait(false);
     }

--- a/backend/MenuApi/Services/MenuUserService.cs
+++ b/backend/MenuApi/Services/MenuUserService.cs
@@ -1,0 +1,12 @@
+using MenuApi.Repositories;
+using MenuApi.ValueObjects;
+
+namespace MenuApi.Services;
+
+public class MenuUserService(IMenuUserRepository menuUserRepository) : IMenuUserService
+{
+    public async Task<MenuUserId> ProvisionAsync(string authSubject, string displayName, string? email, string? avatarUrl)
+    {
+        return await menuUserRepository.UpsertAsync(authSubject, displayName, email, avatarUrl).ConfigureAwait(false);
+    }
+}

--- a/backend/MenuApi/ViewModel/UserProfile.cs
+++ b/backend/MenuApi/ViewModel/UserProfile.cs
@@ -1,0 +1,20 @@
+using MenuApi.ValueObjects;
+
+namespace MenuApi.ViewModel;
+
+public sealed record UserProfile
+{
+    public required MenuUserId Id { get; init; }
+
+    public required string AuthSubject { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public string? Email { get; init; }
+
+    public string? AvatarUrl { get; init; }
+
+    public required DateTime CreatedAtUtc { get; init; }
+
+    public required DateTime LastSeenAtUtc { get; init; }
+}


### PR DESCRIPTION
## Why
Authenticated API calls need a stable local `MenuUser` identity so downstream handlers can work with internal IDs and user metadata, even when Auth0 claims vary by token type.

## What changed
- Added end-to-end user provisioning on authenticated requests via `UserProvisioningMiddleware`.
- Added `IMenuUserRepository`/`MenuUserRepository` and `IMenuUserService`/`MenuUserService` for upsert and lookup flows.
- Added `/api/user/me` endpoint returning persisted user profile data from the database.
- Added new `UserProfile` view model and tests (unit + integration) covering first provision, repeat requests, concurrency, and persisted data visibility.
- Hardened claim handling by truncating inputs to DB column limits and preserving existing profile fields when claims are missing.

## Performance impact
- Optimized the hot upsert path for existing users to use `ExecuteUpdateAsync` instead of loading tracked entities, reducing per-request EF tracking overhead.
- Concurrency handling still guarantees a single row per `AuthSubject` and updates `LastSeenAtUtc` safely.

## Validation
- Built `MenuApi.sln`.
- Ran `MenuApi.Tests`.

Fixes: #1110