### PR TITLE
Update .NET dependencies (simple version bumps)

### DIFF
--- a/backend/Menu.ApiServiceDefaults/Menu.ApiServiceDefaults.csproj
+++ b/backend/Menu.ApiServiceDefaults/Menu.ApiServiceDefaults.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/Menu.ServiceDefaults/Menu.ServiceDefaults.csproj
+++ b/backend/Menu.ServiceDefaults/Menu.ServiceDefaults.csproj
@@ -10,12 +10,12 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 

--- a/backend/MenuApi.Tests/MenuApi.Tests.csproj
+++ b/backend/MenuApi.Tests/MenuApi.Tests.csproj
@@ -37,7 +37,7 @@
 		</PackageReference>
 		<PackageReference Include="FakeItEasy" Version="9.0.1" />
 		<PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 	</ItemGroup>

--- a/backend/MenuApi/MenuApi.csproj
+++ b/backend/MenuApi/MenuApi.csproj
@@ -33,7 +33,7 @@
 		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/backend/MenuDB.Tests/MenuDB.Tests.csproj
+++ b/backend/MenuDB.Tests/MenuDB.Tests.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />

--- a/backend/MenuDB/MenuDB.csproj
+++ b/backend/MenuDB/MenuDB.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary

This PR updates 12 .NET NuGet packages across 6 projects with simple version bumps to their latest stable releases.

## Grouping Rationale

These packages are grouped together because they only require version number changes in `.csproj` files—no code changes, tool updates, or migration steps are needed.

## Update Classification

**Simple version bump** — only project file version edits required.

## Packages Updated

### Entity Framework Core (10.0.8 → 10.0.9)
- `Microsoft.EntityFrameworkCore.Design` in MenuDB, MenuApi
- `Microsoft.EntityFrameworkCore.SqlServer` in MenuDB
- `Microsoft.EntityFrameworkCore.InMemory` in MenuDB.Tests, MenuApi.Tests

### Microsoft.Extensions (10.6.0 → 10.7.0)
- `Microsoft.Extensions.Http.Resilience` in Menu.ServiceDefaults
- `Microsoft.Extensions.ServiceDiscovery` in Menu.ServiceDefaults

### OpenTelemetry (→ 1.16.0)
- `OpenTelemetry.Exporter.OpenTelemetryProtocol` (1.15.3 → 1.16.0)
- `OpenTelemetry.Extensions.Hosting` (1.15.3 → 1.16.0)
- `OpenTelemetry.Instrumentation.AspNetCore` (1.15.2 → 1.16.0)
- `OpenTelemetry.Instrumentation.Http` (1.15.1 → 1.16.0)

All in Menu.ServiceDefaults

### Swashbuckle
- `Swashbuckle.AspNetCore` (10.1.7 → 10.2.3) in Menu.ApiServiceDefaults

## Best Practice Changes

No new best-practice changes were introduced or suggested by these updates.

**Decision:** Do not implement now (no action required).

## Validation

All validation commands completed successfully:

✅ **Backend Build & Test**
```bash
cd backend
dotnet restore MenuApi.sln
dotnet build MenuApi.sln --configuration Release --no-restore
dotnet test --project MenuApi.Tests/MenuApi.Tests.csproj --configuration Release --no-build
```
- All projects built successfully
- 58/58 unit tests passed

✅ **Frontend Build & Lint**
```bash
cd ui/menu-website
corepack enable pnpm
pnpm install --frozen-lockfile
pnpm run generate-openapi
pnpm run lint
pnpm run build
```
- OpenAPI types regenerated successfully
- Lint passed with no errors
- Production build completed successfully

**Note:** Integration tests and frontend e2e tests could not be run due to pre-existing infrastructure issues unrelated to these updates (MessagePack vulnerability warnings in integration tests, Playwright browser download blocked by network policy).




> [!WARNING]
> <details>
> <summary>Firewall blocked 3 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `169.254.169.254`
> - `cdn.playwright.dev`
> - `rt.services.visualstudio.com`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "169.254.169.254"
>     - "cdn.playwright.dev"
>     - "rt.services.visualstudio.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Dependency Update Dotnet](https://github.com/dgee2/Menu/actions/runs/28653309849) · ● 31.9M · [◷](https://github.com/search?q=repo%3Adgee2%2FMenu+%22gh-aw-workflow-id%3A+dependency-update-dotnet%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Dependency Update Dotnet, engine: copilot, version: 1.0.48, model: claude-sonnet-4.5, id: 28653309849, workflow_id: dependency-update-dotnet, run: https://github.com/dgee2/Menu/actions/runs/28653309849 -->

<!-- gh-aw-workflow-id: dependency-update-dotnet -->