### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@AGENTS.md
+
+## Additional Reference Docs
+
+These go deeper than AGENTS.md on specific workflows — consult them before working in these areas:
+
+- `docs/database-migrations.md` — EF Core migration creation/review workflow, naming conventions, what not to hand-edit
+- `docs/integration-tests.md` — `ApiTestFixture` architecture, Auth0 M2M test auth, seed data from the `InitialCreate` migration, sequential execution model
+- `docs/ci-path-filters.md` — which CI jobs run for backend-only/frontend-only/`open-api/`-only changes
+- `docs/specs/` — architecture and design specs for larger features (e.g. `recipe-creation-target-architecture.md`)


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` as the entry point Claude Code reads, importing the existing `AGENTS.md` via `@AGENTS.md` so the two stay in sync instead of duplicating content
- Links to the deeper reference docs under `docs/` (EF migrations, integration tests, CI path filters, specs) that go beyond what `AGENTS.md` summarizes

## Test plan
- [x] N/A — documentation-only change