### PR TITLE
Add ownership-aware recipe list endpoint (scope=mine|authenticated)

### DIFF
--- a/backend/MenuApi.Integration.Tests/Factory/TestDatabaseSeeder.cs
+++ b/backend/MenuApi.Integration.Tests/Factory/TestDatabaseSeeder.cs
@@ -19,10 +19,13 @@ internal static class TestDatabaseSeeder
     {
         await using var db = await CreateDbContextAsync(fixture, cancellationToken);
 
+        var now = DateTime.UtcNow;
         var entity = new MenuUserEntity
         {
             AuthSubject = authSubject,
             DisplayName = authSubject,
+            CreatedAtUtc = now,
+            LastSeenAtUtc = now,
         };
 
         db.MenuUsers.Add(entity);

--- a/backend/MenuApi.Integration.Tests/Factory/TestDatabaseSeeder.cs
+++ b/backend/MenuApi.Integration.Tests/Factory/TestDatabaseSeeder.cs
@@ -1,0 +1,66 @@
+using Aspire.Hosting.Testing;
+using MenuDB;
+using MenuDB.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace MenuApi.Integration.Tests.Factory;
+
+/// <summary>
+/// Seeds rows directly into the shared integration-test database, bypassing the API.
+/// Used to exercise ownership/scope behavior that can't be produced through the API alone,
+/// since all HTTP calls in these tests authenticate as the same fixed Auth0 M2M identity.
+/// </summary>
+internal static class TestDatabaseSeeder
+{
+    public static async Task<int> AddMenuUserAsync(
+        ApiTestFixture fixture,
+        string authSubject,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await CreateDbContextAsync(fixture, cancellationToken);
+
+        var entity = new MenuUserEntity
+        {
+            AuthSubject = authSubject,
+            DisplayName = authSubject,
+        };
+
+        db.MenuUsers.Add(entity);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return entity.Id;
+    }
+
+    public static async Task<int> AddRecipeAsync(
+        ApiTestFixture fixture,
+        string title,
+        int ownerUserId,
+        string accessScope,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await CreateDbContextAsync(fixture, cancellationToken);
+
+        var entity = new RecipeEntity
+        {
+            Title = title,
+            OwnerUserId = ownerUserId,
+            AccessScope = accessScope,
+        };
+
+        db.Recipes.Add(entity);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return entity.Id;
+    }
+
+    private static async Task<MenuDbContext> CreateDbContextAsync(ApiTestFixture fixture, CancellationToken cancellationToken)
+    {
+        var connectionString = await fixture.app.GetConnectionStringAsync("menu", cancellationToken);
+
+        var options = new DbContextOptionsBuilder<MenuDbContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+
+        return new MenuDbContext(options);
+    }
+}

--- a/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
+++ b/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
@@ -41,6 +41,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\Menu.AppHost\Menu.AppHost.csproj" />
+	  <ProjectReference Include="..\MenuDB\MenuDB.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -27,7 +27,7 @@ public class RecipeIntegrationTests
     public async Task Get_ReturnsAListOfRecipes()
     {
         using var client = await fixture.GetHttpClient();
-        using var response = await client.GetAsync("/api/recipe");
+        using var response = await client.GetAsync("/api/recipe?scope=mine");
 
         await response.ShouldHaveStatusCode(HttpStatusCode.OK);
 
@@ -35,6 +35,15 @@ public class RecipeIntegrationTests
 
         var deserializedData = JsonSerializer.Deserialize<HashSet<RecipeListItem>>(data, jsonOptions);
         deserializedData.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Get_UnknownScope_ReturnsBadRequest()
+    {
+        using var client = await fixture.GetHttpClient();
+        using var response = await client.GetAsync("/api/recipe?scope=everyone");
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
     }
 
     [Theory]

--- a/backend/MenuApi.Integration.Tests/RecipeScopeIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeScopeIntegrationTests.cs
@@ -1,0 +1,91 @@
+using AwesomeAssertions;
+using MenuApi.Integration.Tests.Factory;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace MenuApi.Integration.Tests;
+
+[Collection("API Host Collection")]
+public class RecipeScopeIntegrationTests
+{
+    private readonly JsonSerializerOptions jsonOptions;
+    private readonly ApiTestFixture fixture;
+
+    public RecipeScopeIntegrationTests(ApiTestFixture fixture)
+    {
+        jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ScopeMine_ExcludesRecipesOwnedByOtherUsers()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = await fixture.GetHttpClient();
+
+        var myTitle = $"My Recipe {Guid.NewGuid()}";
+        await PostRecipeAsync(client, myTitle, "Private");
+
+        var otherOwnerId = await TestDatabaseSeeder.AddMenuUserAsync(fixture, $"other-user-{Guid.NewGuid()}", cancellationToken);
+        var otherTitle = $"Someone Else's Recipe {Guid.NewGuid()}";
+        await TestDatabaseSeeder.AddRecipeAsync(fixture, otherTitle, otherOwnerId, "Private", cancellationToken);
+
+        var titles = await GetRecipeTitlesAsync(client, "mine");
+
+        titles.Should().Contain(myTitle);
+        titles.Should().NotContain(otherTitle);
+    }
+
+    [Fact]
+    public async Task ScopeAuthenticated_ReturnsAuthenticatedScopedRecipesRegardlessOfOwner()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = await fixture.GetHttpClient();
+
+        var myPrivateTitle = $"My Private Recipe {Guid.NewGuid()}";
+        await PostRecipeAsync(client, myPrivateTitle, "Private");
+
+        var mySharedTitle = $"My Shared Recipe {Guid.NewGuid()}";
+        await PostRecipeAsync(client, mySharedTitle, "AuthenticatedUsers");
+
+        var otherOwnerId = await TestDatabaseSeeder.AddMenuUserAsync(fixture, $"other-user-{Guid.NewGuid()}", cancellationToken);
+        var otherSharedTitle = $"Someone Else's Shared Recipe {Guid.NewGuid()}";
+        await TestDatabaseSeeder.AddRecipeAsync(fixture, otherSharedTitle, otherOwnerId, "AuthenticatedUsers", cancellationToken);
+
+        var titles = await GetRecipeTitlesAsync(client, "authenticated");
+
+        titles.Should().Contain(mySharedTitle);
+        titles.Should().Contain(otherSharedTitle);
+        titles.Should().NotContain(myPrivateTitle);
+    }
+
+    private async Task<HashSet<string>> GetRecipeTitlesAsync(HttpClient client, string scope)
+    {
+        using var response = await client.GetAsync($"/api/recipe?scope={scope}&take=200");
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        var data = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(data);
+
+        return doc.RootElement.EnumerateArray()
+            .Select(e => e.GetProperty("title").GetString()!)
+            .ToHashSet();
+    }
+
+    private async Task PostRecipeAsync(HttpClient client, string title, string accessScope)
+    {
+        var body = new
+        {
+            Title = title,
+            AccessScope = accessScope,
+            Ingredients = new[] { new { SortOrder = 0, IngredientText = "Water", MeasureText = "1 cup", IsOptional = false } },
+            Steps = Array.Empty<object>(),
+        };
+
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+    }
+}

--- a/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
+++ b/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
@@ -95,6 +95,17 @@ public class RecipeApiTests
 
         var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
         problemResult.StatusCode.Should().Be(400);
+        problemResult.ProblemDetails.Detail.Should().Be("Unknown scope 'everyone'. Expected 'mine' or 'authenticated'.");
+    }
+
+    [Theory, CustomAutoData]
+    public async Task GetRecipesAsync_MissingScope_Returns400(MenuUserId callerId)
+    {
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(callerId), null, null);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(400);
+        problemResult.ProblemDetails.Detail.Should().Be("Missing scope. Expected 'mine' or 'authenticated'.");
     }
 
     [Fact]

--- a/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
+++ b/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
@@ -2,10 +2,12 @@
 
 using AwesomeAssertions;
 using FakeItEasy;
+using MenuApi.Middleware;
 using MenuApi.Recipes;
 using MenuApi.Services;
 using MenuApi.ValueObjects;
 using MenuApi.ViewModel;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Xunit;
 
@@ -20,14 +22,87 @@ public class RecipeApiTests
         recipeService = A.Fake<IRecipeService>();
     }
 
-    [Theory, CustomAutoData]
-    public async Task GetRecipesAsync_Success(IEnumerable<RecipeListItem> recipes)
+    private static HttpContext CreateHttpContext(MenuUserId? menuUserId)
     {
-        A.CallTo(() => recipeService.GetRecipesAsync()).Returns(recipes);
+        var httpContext = new DefaultHttpContext();
+        if (menuUserId is not null)
+        {
+            httpContext.Items[MenuUserHttpContextKeys.MenuUserId] = menuUserId.Value;
+        }
 
-        var result = await RecipeApi.GetRecipesAsync(recipeService);
+        return httpContext;
+    }
 
-        result.Should().BeEquivalentTo(recipes);
+    [Theory, CustomAutoData]
+    public async Task GetRecipesAsync_Mine_Success(MenuUserId callerId, IEnumerable<RecipeListItem> recipes)
+    {
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Mine, callerId, 50)).Returns(recipes);
+
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(callerId), "mine", null);
+
+        var okResult = result.Should().BeOfType<Ok<IEnumerable<RecipeListItem>>>().Subject;
+        okResult.Value.Should().BeEquivalentTo(recipes);
+    }
+
+    [Theory, CustomAutoData]
+    public async Task GetRecipesAsync_Authenticated_Success(MenuUserId callerId, IEnumerable<RecipeListItem> recipes)
+    {
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Authenticated, callerId, 50)).Returns(recipes);
+
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(callerId), "AUTHENTICATED", null);
+
+        var okResult = result.Should().BeOfType<Ok<IEnumerable<RecipeListItem>>>().Subject;
+        okResult.Value.Should().BeEquivalentTo(recipes);
+    }
+
+    [Theory, CustomAutoData]
+    public async Task GetRecipesAsync_ClampsTakeToMax(MenuUserId callerId, IEnumerable<RecipeListItem> recipes)
+    {
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Mine, callerId, 200)).Returns(recipes);
+
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(callerId), "mine", 500);
+
+        result.Should().BeOfType<Ok<IEnumerable<RecipeListItem>>>();
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Mine, callerId, 200)).MustHaveHappenedOnceExactly();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task GetRecipesAsync_ClampsZeroTakeToMin(MenuUserId callerId, IEnumerable<RecipeListItem> recipes)
+    {
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Mine, callerId, 1)).Returns(recipes);
+
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(callerId), "mine", 0);
+
+        result.Should().BeOfType<Ok<IEnumerable<RecipeListItem>>>();
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Mine, callerId, 1)).MustHaveHappenedOnceExactly();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task GetRecipesAsync_ClampsNegativeTakeToMin(MenuUserId callerId, IEnumerable<RecipeListItem> recipes)
+    {
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Mine, callerId, 1)).Returns(recipes);
+
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(callerId), "mine", -1);
+
+        result.Should().BeOfType<Ok<IEnumerable<RecipeListItem>>>();
+        A.CallTo(() => recipeService.GetRecipesAsync(RecipeListScope.Mine, callerId, 1)).MustHaveHappenedOnceExactly();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task GetRecipesAsync_UnknownScope_Returns400(MenuUserId callerId)
+    {
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(callerId), "everyone", null);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task GetRecipesAsync_NoMenuUserId_Returns401()
+    {
+        var result = await RecipeApi.GetRecipesAsync(recipeService, CreateHttpContext(null), "mine", null);
+
+        result.Should().BeOfType<UnauthorizedHttpResult>();
     }
 
     [Theory, CustomAutoData]
@@ -64,15 +139,24 @@ public class RecipeApiTests
     }
 
     [Theory, CustomAutoData]
-    public async Task CreateRecipeAsync_Success(UpsertRecipe upsertRecipe, RecipeDetail recipe, RecipeId recipeId)
+    public async Task CreateRecipeAsync_Success(MenuUserId callerId, UpsertRecipe upsertRecipe, RecipeDetail recipe, RecipeId recipeId)
     {
-        A.CallTo(() => recipeService.CreateRecipeAsync(upsertRecipe)).Returns(recipeId);
+        A.CallTo(() => recipeService.CreateRecipeAsync(upsertRecipe, callerId)).Returns(recipeId);
         A.CallTo(() => recipeService.GetRecipeAsync(recipeId)).Returns(recipe);
 
-        var result = await RecipeApi.CreateRecipeAsync(recipeService, upsertRecipe);
+        var result = await RecipeApi.CreateRecipeAsync(recipeService, CreateHttpContext(callerId), upsertRecipe);
 
-        A.CallTo(() => recipeService.CreateRecipeAsync(upsertRecipe)).MustHaveHappenedOnceExactly();
-        result.Should().Be(recipe);
+        A.CallTo(() => recipeService.CreateRecipeAsync(upsertRecipe, callerId)).MustHaveHappenedOnceExactly();
+        var okResult = result.Should().BeOfType<Ok<RecipeDetail>>().Subject;
+        okResult.Value.Should().Be(recipe);
+    }
+
+    [Theory, CustomAutoData]
+    public async Task CreateRecipeAsync_NoMenuUserId_Returns401(UpsertRecipe upsertRecipe)
+    {
+        var result = await RecipeApi.CreateRecipeAsync(recipeService, CreateHttpContext(null), upsertRecipe);
+
+        result.Should().BeOfType<UnauthorizedHttpResult>();
     }
 
     [Theory, CustomAutoData]

--- a/backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs
+++ b/backend/MenuApi.Tests/Repositories/RecipeRepositoryTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using MenuDB;
+using MenuDB.Data;
 using MenuApi.Repositories;
 using MenuApi.ValueObjects;
 using Microsoft.EntityFrameworkCore;
@@ -33,6 +34,71 @@ public class RecipeRepositoryTests
         entity.CreatedAtUtc.Should().NotBe(default);
         entity.UpdatedAtUtc.Should().NotBe(default);
         entity.UpdatedAtUtc.Should().Be(entity.CreatedAtUtc);
+    }
+
+    [Fact]
+    public async Task GetRecipesAsync_Mine_ReturnsOnlyCallersRecipes()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var sut = new RecipeRepository(db);
+
+        var owner = MenuUserId.From(1);
+        var otherOwner = MenuUserId.From(2);
+        AddRecipe(db, "Mine 1", owner, RecipeAccessScope.Private);
+        AddRecipe(db, "Someone Else's", otherOwner, RecipeAccessScope.Private);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var result = await sut.GetRecipesAsync(RecipeListScope.Mine, owner, 50);
+
+        result.Should().ContainSingle(r => r.Title == RecipeTitle.From("Mine 1"));
+    }
+
+    [Fact]
+    public async Task GetRecipesAsync_Authenticated_ReturnsAuthenticatedScopedRecipesRegardlessOfOwner()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var sut = new RecipeRepository(db);
+
+        var caller = MenuUserId.From(1);
+        var otherOwner = MenuUserId.From(2);
+        AddRecipe(db, "Private Mine", caller, RecipeAccessScope.Private);
+        AddRecipe(db, "Shared By Me", caller, RecipeAccessScope.AuthenticatedUsers);
+        AddRecipe(db, "Shared By Someone Else", otherOwner, RecipeAccessScope.AuthenticatedUsers);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var result = await sut.GetRecipesAsync(RecipeListScope.Authenticated, caller, 50);
+
+        result.Select(r => r.Title.Value).Should().BeEquivalentTo(["Shared By Me", "Shared By Someone Else"]);
+    }
+
+    [Fact]
+    public async Task GetRecipesAsync_RespectsTakeLimit()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var sut = new RecipeRepository(db);
+
+        var owner = MenuUserId.From(1);
+        AddRecipe(db, "Recipe 1", owner, RecipeAccessScope.Private);
+        AddRecipe(db, "Recipe 2", owner, RecipeAccessScope.Private);
+        AddRecipe(db, "Recipe 3", owner, RecipeAccessScope.Private);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var result = await sut.GetRecipesAsync(RecipeListScope.Mine, owner, 2);
+
+        result.Should().HaveCount(2);
+    }
+
+    private static void AddRecipe(MenuDbContext db, string title, MenuUserId ownerId, string accessScope)
+    {
+        db.Recipes.Add(new RecipeEntity
+        {
+            Title = title,
+            OwnerUserId = ownerId.Value,
+            AccessScope = accessScope,
+        });
     }
 
     private static MenuDbContext CreateDbContext()

--- a/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
@@ -75,7 +75,7 @@ public class RecipeServiceTests
     }
 
     [Theory, CustomAutoData]
-    public async Task GetRecipesSuccess(IEnumerable<DBModel.Recipe> recipes)
+    public async Task GetRecipesSuccess(RecipeListScope scope, MenuUserId callerId, IEnumerable<DBModel.Recipe> recipes)
     {
         var expected = recipes.Select(x => new RecipeListItem
         {
@@ -89,9 +89,9 @@ public class RecipeServiceTests
             CookTimeMinutes = x.CookTimeMinutes,
             TotalTimeMinutes = x.TotalTimeMinutes,
         });
-        A.CallTo(() => recipeRepository.GetRecipesAsync()).Returns(recipes.AsEnumerable());
+        A.CallTo(() => recipeRepository.GetRecipesAsync(scope, callerId, 50)).Returns(recipes.AsEnumerable());
 
-        var result = await sut.GetRecipesAsync();
+        var result = await sut.GetRecipesAsync(scope, callerId, 50);
         result.Should().BeEquivalentTo(expected);
     }
 
@@ -119,14 +119,14 @@ public class RecipeServiceTests
     }
 
     [Theory, CustomAutoData]
-    public async Task CreateRecipeSuccess(RecipeId recipeId, UpsertRecipe upsertRecipe)
+    public async Task CreateRecipeSuccess(RecipeId recipeId, MenuUserId callerId, UpsertRecipe upsertRecipe)
     {
         A.CallTo(() => recipeRepository.CreateRecipeAsync(A<DBModel.Recipe>._)).Returns(recipeId);
 
-        await sut.CreateRecipeAsync(upsertRecipe);
+        await sut.CreateRecipeAsync(upsertRecipe, callerId);
 
         A.CallTo(() => recipeRepository.CreateRecipeAsync(A<DBModel.Recipe>.That.Matches(
-            r => r.Title == upsertRecipe.Title && r.AccessScope == upsertRecipe.AccessScope)))
+            r => r.Title == upsertRecipe.Title && r.AccessScope == upsertRecipe.AccessScope && r.OwnerUserId == callerId)))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(recipeId, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustHaveHappenedOnceExactly();
     }

--- a/backend/MenuApi/Recipes/RecipeApi.cs
+++ b/backend/MenuApi/Recipes/RecipeApi.cs
@@ -58,8 +58,12 @@ public static class RecipeApi
 
         if (!TryParseScope(scope, out var recipeListScope))
         {
+            var detail = string.IsNullOrEmpty(scope)
+                ? "Missing scope. Expected 'mine' or 'authenticated'."
+                : $"Unknown scope '{scope}'. Expected 'mine' or 'authenticated'.";
+
             return Results.Problem(
-                detail: $"Unknown scope '{scope}'. Expected 'mine' or 'authenticated'.",
+                detail: detail,
                 statusCode: StatusCodes.Status400BadRequest);
         }
 

--- a/backend/MenuApi/Recipes/RecipeApi.cs
+++ b/backend/MenuApi/Recipes/RecipeApi.cs
@@ -1,3 +1,4 @@
+using MenuApi.Middleware;
 using MenuApi.Services;
 using MenuApi.Validation;
 using MenuApi.ValueObjects;
@@ -7,6 +8,9 @@ namespace MenuApi.Recipes;
 
 public static class RecipeApi
 {
+    private const int DefaultTake = 50;
+    private const int MaxTake = 200;
+
     public static RouteGroupBuilder MapRecipes(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/recipe");
@@ -14,7 +18,9 @@ public static class RecipeApi
         group.WithTags("Recipes");
 
         group.MapGet("/", GetRecipesAsync)
-            .Produces<IEnumerable<RecipeListItem>>(StatusCodes.Status200OK);
+            .Produces<IEnumerable<RecipeListItem>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapGet("/{recipeId}", GetRecipeAsync)
             .Produces<RecipeDetail>(StatusCodes.Status200OK)
@@ -27,7 +33,8 @@ public static class RecipeApi
             .AddEndpointFilter<ValidationFilter<UpsertRecipe>>()
             .Produces<RecipeDetail>(StatusCodes.Status200OK)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapPut("{recipeId}", UpdateRecipeAsync)
             .AddEndpointFilter<ValidationFilter<UpsertRecipe>>()
@@ -38,9 +45,44 @@ public static class RecipeApi
         return group;
     }
 
-    public static async Task<IEnumerable<RecipeListItem>> GetRecipesAsync(IRecipeService recipeService)
+    public static async Task<IResult> GetRecipesAsync(
+        IRecipeService recipeService,
+        HttpContext httpContext,
+        string? scope,
+        int? take)
     {
-        return await recipeService.GetRecipesAsync();
+        if (httpContext.Items[MenuUserHttpContextKeys.MenuUserId] is not MenuUserId callerId)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!TryParseScope(scope, out var recipeListScope))
+        {
+            return Results.Problem(
+                detail: $"Unknown scope '{scope}'. Expected 'mine' or 'authenticated'.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var boundedTake = Math.Clamp(take ?? DefaultTake, 1, MaxTake);
+
+        var recipes = await recipeService.GetRecipesAsync(recipeListScope, callerId, boundedTake);
+        return Results.Ok(recipes);
+    }
+
+    private static bool TryParseScope(string? scope, out RecipeListScope recipeListScope)
+    {
+        switch (scope?.ToLowerInvariant())
+        {
+            case "mine":
+                recipeListScope = RecipeListScope.Mine;
+                return true;
+            case "authenticated":
+                recipeListScope = RecipeListScope.Authenticated;
+                return true;
+            default:
+                recipeListScope = default;
+                return false;
+        }
     }
 
     public static async Task<IResult> GetRecipeAsync(IRecipeService recipeService, RecipeId recipeId)
@@ -58,11 +100,16 @@ public static class RecipeApi
         return await recipeService.GetRecipeIngredientsAsync(recipeId);
     }
 
-    public static async Task<RecipeDetail> CreateRecipeAsync(IRecipeService recipeService, UpsertRecipe upsertRecipe)
+    public static async Task<IResult> CreateRecipeAsync(IRecipeService recipeService, HttpContext httpContext, UpsertRecipe upsertRecipe)
     {
-        var recipeId = await recipeService.CreateRecipeAsync(upsertRecipe);
+        if (httpContext.Items[MenuUserHttpContextKeys.MenuUserId] is not MenuUserId callerId)
+        {
+            return Results.Unauthorized();
+        }
+
+        var recipeId = await recipeService.CreateRecipeAsync(upsertRecipe, callerId);
         var recipe = await recipeService.GetRecipeAsync(recipeId);
-        return recipe ?? throw new InvalidOperationException("Recipe creation failed");
+        return Results.Ok(recipe ?? throw new InvalidOperationException("Recipe creation failed"));
     }
 
     public static async Task<RecipeDetail> UpdateRecipeAsync(IRecipeService recipeService, RecipeId recipeId, UpsertRecipe upsertRecipe)

--- a/backend/MenuApi/Repositories/IRecipeRepository.cs
+++ b/backend/MenuApi/Repositories/IRecipeRepository.cs
@@ -12,7 +12,7 @@ public interface IRecipeRepository
 
     Task<IEnumerable<DBModel.RecipeIngredient>> GetRecipeIngredientsAsync(RecipeId recipeId);
 
-    Task<IEnumerable<DBModel.Recipe>> GetRecipesAsync();
+    Task<IEnumerable<DBModel.Recipe>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take);
 
     Task UpdateRecipeAsync(RecipeId recipeId, DBModel.Recipe recipe);
 }

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -12,9 +12,18 @@ namespace MenuApi.Repositories;
 [ExcludeFromCodeCoverage]
 public class RecipeRepository(MenuDbContext db) : IRecipeRepository
 {
-    public async Task<IEnumerable<DBModel.Recipe>> GetRecipesAsync()
+    public async Task<IEnumerable<DBModel.Recipe>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take)
     {
-        return await db.Recipes
+        var query = scope switch
+        {
+            RecipeListScope.Mine => db.Recipes.Where(r => r.OwnerUserId == callerId.Value),
+            RecipeListScope.Authenticated => db.Recipes.Where(r => r.AccessScope == RecipeAccessScope.AuthenticatedUsers),
+            _ => throw new ArgumentOutOfRangeException(nameof(scope), scope, "Unsupported recipe list scope."),
+        };
+
+        return await query
+            .OrderByDescending(r => r.UpdatedAtUtc)
+            .Take(take)
             .Select(r => MapToDbModel(r))
             .ToListAsync()
             .ConfigureAwait(false);

--- a/backend/MenuApi/Services/IRecipeService.cs
+++ b/backend/MenuApi/Services/IRecipeService.cs
@@ -5,13 +5,13 @@ namespace MenuApi.Services;
 
 public interface IRecipeService
 {
-    Task<RecipeId> CreateRecipeAsync(UpsertRecipe upsertRecipe);
+    Task<RecipeId> CreateRecipeAsync(UpsertRecipe upsertRecipe, MenuUserId callerId);
 
     Task<RecipeDetail?> GetRecipeAsync(RecipeId recipeId);
 
     Task<IEnumerable<RecipeIngredientItem>> GetRecipeIngredientsAsync(RecipeId recipeId);
 
-    Task<IEnumerable<RecipeListItem>> GetRecipesAsync();
+    Task<IEnumerable<RecipeListItem>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take);
 
     Task UpdateRecipeAsync(RecipeId recipeId, UpsertRecipe upsertRecipe);
 }

--- a/backend/MenuApi/Services/RecipeService.cs
+++ b/backend/MenuApi/Services/RecipeService.cs
@@ -9,9 +9,9 @@ namespace MenuApi.Services;
 
 public class RecipeService(IRecipeRepository recipeRepository, IRecipeStepRepository recipeStepRepository, MenuDbContext db) : IRecipeService
 {
-    public async Task<IEnumerable<RecipeListItem>> GetRecipesAsync()
+    public async Task<IEnumerable<RecipeListItem>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take)
     {
-        var recipes = await recipeRepository.GetRecipesAsync().ConfigureAwait(false);
+        var recipes = await recipeRepository.GetRecipesAsync(scope, callerId, take).ConfigureAwait(false);
         return ViewModelMapper.Map(recipes);
     }
 
@@ -38,15 +38,17 @@ public class RecipeService(IRecipeRepository recipeRepository, IRecipeStepReposi
         return ViewModelMapper.Map(ingredients);
     }
 
-    public async Task<RecipeId> CreateRecipeAsync(UpsertRecipe upsertRecipe)
+    public async Task<RecipeId> CreateRecipeAsync(UpsertRecipe upsertRecipe, MenuUserId callerId)
     {
         ArgumentNullException.ThrowIfNull(upsertRecipe);
+
+        var recipe = ViewModelMapper.Map(upsertRecipe) with { OwnerUserId = callerId };
 
         var strategy = db.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {
             await using var tran = await db.Database.BeginTransactionAsync().ConfigureAwait(false);
-            var recipeId = await recipeRepository.CreateRecipeAsync(ViewModelMapper.Map(upsertRecipe)).ConfigureAwait(false);
+            var recipeId = await recipeRepository.CreateRecipeAsync(recipe).ConfigureAwait(false);
             await recipeRepository.UpsertRecipeIngredientsAsync(recipeId, ViewModelMapper.Map(upsertRecipe.Ingredients)).ConfigureAwait(false);
             await tran.CommitAsync().ConfigureAwait(false);
             return recipeId;

--- a/backend/MenuApi/ValueObjects/RecipeListScope.cs
+++ b/backend/MenuApi/ValueObjects/RecipeListScope.cs
@@ -1,0 +1,7 @@
+namespace MenuApi.ValueObjects;
+
+public enum RecipeListScope
+{
+    Mine,
+    Authenticated,
+}

--- a/ui/menu-website/src/services/recipe-api.ts
+++ b/ui/menu-website/src/services/recipe-api.ts
@@ -25,7 +25,7 @@ export const useRecipeApi = () => {
 
   client.use(authMiddleware);
 
-  const postRecipe = async (recipe: UpsertRecipe) => {
+  const postRecipe = async (recipe: UpsertRecipe): Promise<RecipeDetail> => {
     const { data, error } = await client.POST('/api/recipe', {
       body: recipe,
     });
@@ -35,10 +35,10 @@ export const useRecipeApi = () => {
       throw new Error('Failed to post recipe');
     }
 
-    return data;
+    return data as RecipeDetail;
   };
 
-  const putRecipe = async (recipeId: string, recipe: UpsertRecipe) => {
+  const putRecipe = async (recipeId: string, recipe: UpsertRecipe): Promise<RecipeDetail> => {
     const { data, error } = await client.PUT('/api/recipe/{recipeId}', {
       params: {
         path: {
@@ -53,7 +53,7 @@ export const useRecipeApi = () => {
       throw new Error('Failed to put recipe');
     }
 
-    return data;
+    return data as RecipeDetail;
   };
 
   const getRecipes = async (): Promise<RecipeListItem[]> => {
@@ -63,7 +63,7 @@ export const useRecipeApi = () => {
       throw new Error('Failed to get recipes');
     }
 
-    return data;
+    return data as RecipeListItem[];
   };
 
   const getRecipe = async (recipeId: string): Promise<RecipeDetail> => {


### PR DESCRIPTION
## Summary
- Adds `GET /api/recipe?scope=mine|authenticated`, resolving the caller's `MenuUserId` from the existing provisioning middleware and bounding the result count (default 50, max 200). Unknown scope values return 400.
- Also assigns `OwnerUserId` on recipe creation: without it, `scope=mine` could never return anything since nothing set ownership yet. This is intentionally narrow — no owner check on update, no transaction changes — the remaining ownership/authorization work for update lands in #1116.

Closes #1115
Part of #1099

## Test plan
- [x] `dotnet test MenuApi.Tests` (unit) — repository filter predicate + endpoint scope-parsing/take-clamping
- [x] `dotnet test MenuApi.Integration.Tests` — scope variants using a `TestDatabaseSeeder` helper to seed a second owner directly (the shared test suite otherwise authenticates as a single fixed Auth0 M2M identity)