### PR TITLE
Extend create/update recipe endpoints to accept ingredients and steps

### DIFF
--- a/backend/MenuApi.Integration.Tests/RecipeCreateUpdateIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeCreateUpdateIntegrationTests.cs
@@ -1,0 +1,160 @@
+using AwesomeAssertions;
+using MenuApi.Integration.Tests.Factory;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace MenuApi.Integration.Tests;
+
+[Collection("API Host Collection")]
+public class RecipeCreateUpdateIntegrationTests
+{
+    private readonly JsonSerializerOptions jsonOptions;
+    private readonly ApiTestFixture fixture;
+
+    public RecipeCreateUpdateIntegrationTests(ApiTestFixture fixture)
+    {
+        jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        this.fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("Recipe With Steps")]
+    public async Task Create_Recipe_With_Ingredients_And_Steps_Returns_Both(string recipeTitle)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var body = new
+        {
+            Title = recipeTitle,
+            AccessScope = "Private",
+            Ingredients = new[] { new { SortOrder = 0, IngredientText = "Flour", MeasureText = "200g", IsOptional = false } },
+            Steps = new[] { new { SortOrder = 0, InstructionText = "Mix well." } },
+        };
+
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var root = doc.RootElement;
+
+        root.GetProperty("ingredients").GetArrayLength().Should().Be(1);
+        root.GetProperty("steps").GetArrayLength().Should().Be(1);
+        root.GetProperty("steps")[0].GetProperty("instructionText").GetString().Should().Be("Mix well.");
+    }
+
+    [Theory]
+    [InlineData("Recipe To Update With Steps")]
+    public async Task Update_Recipe_Replaces_Ingredients_And_Steps(string recipeTitle)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var createBody = new
+        {
+            Title = recipeTitle,
+            AccessScope = "Private",
+            Ingredients = new[] { new { SortOrder = 0, IngredientText = "Flour", MeasureText = "200g", IsOptional = false } },
+            Steps = new[] { new { SortOrder = 0, InstructionText = "Original step." } },
+        };
+        using var createContent = new StringContent(JsonSerializer.Serialize(createBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var createResponse = await client.PostAsync("/api/recipe", createContent);
+        await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var createStream = await createResponse.Content.ReadAsStreamAsync();
+        using var createDoc = await JsonDocument.ParseAsync(createStream);
+        var recipeId = createDoc.RootElement.GetProperty("id").GetInt32();
+
+        var updateBody = new
+        {
+            Title = recipeTitle,
+            AccessScope = "Private",
+            Ingredients = new[] { new { SortOrder = 0, IngredientText = "Sugar", MeasureText = "1 cup", IsOptional = false } },
+            Steps = new[]
+            {
+                new { SortOrder = 0, InstructionText = "Updated step one." },
+                new { SortOrder = 1, InstructionText = "Updated step two." },
+            },
+        };
+        using var updateContent = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var updateResponse = await client.PutAsync($"/api/recipe/{recipeId}", updateContent);
+        await updateResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var updateStream = await updateResponse.Content.ReadAsStreamAsync();
+        using var updateDoc = await JsonDocument.ParseAsync(updateStream);
+        var root = updateDoc.RootElement;
+
+        root.GetProperty("ingredients").GetArrayLength().Should().Be(1);
+        root.GetProperty("ingredients")[0].GetProperty("ingredientText").GetString().Should().Be("Sugar");
+        root.GetProperty("steps").GetArrayLength().Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData("Minimal Recipe")]
+    public async Task Create_Recipe_With_Zero_Ingredients_And_Steps_Succeeds(string recipeTitle)
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var body = new
+        {
+            Title = recipeTitle,
+            AccessScope = "Private",
+            Ingredients = Array.Empty<object>(),
+            Steps = Array.Empty<object>(),
+        };
+
+        using var content = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/api/recipe", content);
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var root = doc.RootElement;
+
+        root.GetProperty("ingredients").GetArrayLength().Should().Be(0);
+        root.GetProperty("steps").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Update_Recipe_NotOwner_Returns403()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = await fixture.GetHttpClient();
+
+        var otherOwnerId = await TestDatabaseSeeder.AddMenuUserAsync(fixture, $"other-user-{Guid.NewGuid()}", cancellationToken);
+        var recipeId = await TestDatabaseSeeder.AddRecipeAsync(
+            fixture, $"Someone Else's Recipe {Guid.NewGuid()}", otherOwnerId, "Private", cancellationToken);
+
+        var updateBody = new
+        {
+            Title = "Attempted Takeover",
+            AccessScope = "Private",
+            Ingredients = Array.Empty<object>(),
+            Steps = Array.Empty<object>(),
+        };
+        using var content = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PutAsync($"/api/recipe/{recipeId}", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Update_Recipe_NotFound_Returns404()
+    {
+        using var client = await fixture.GetHttpClient();
+
+        var updateBody = new
+        {
+            Title = "Does Not Exist",
+            AccessScope = "Private",
+            Ingredients = Array.Empty<object>(),
+            Steps = Array.Empty<object>(),
+        };
+        using var content = new StringContent(JsonSerializer.Serialize(updateBody, jsonOptions), Encoding.UTF8, "application/json");
+        using var response = await client.PutAsync("/api/recipe/999999999", content);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+    }
+}

--- a/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeIntegrationTests.cs
@@ -143,7 +143,7 @@ public class RecipeIntegrationTests
 
     [Theory]
     [InlineData("Unique Title")]
-    public async Task Create_Recipe_With_Duplicate_Title_Returns_UnprocessableEntity(string recipeTitle)
+    public async Task Create_Recipe_With_Duplicate_Title_Returns_Conflict(string recipeTitle)
     {
         using var client = await fixture.GetHttpClient();
         var recipe = new UpsertRecipe
@@ -160,12 +160,12 @@ public class RecipeIntegrationTests
         using var requestContent = new StringContent(JsonSerializer.Serialize(recipe), Encoding.UTF8, "application/json");
         using var response = await client.PostAsync("/api/recipe", requestContent);
 
-        await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+        await response.ShouldHaveStatusCode(HttpStatusCode.Conflict);
     }
 
     [Theory]
     [InlineData("Recipe A", "Recipe B")]
-    public async Task Update_Recipe_To_Duplicate_Title_Returns_UnprocessableEntity(string recipeTitle1, string recipeTitle2)
+    public async Task Update_Recipe_To_Duplicate_Title_Returns_Conflict(string recipeTitle1, string recipeTitle2)
     {
         using var client = await fixture.GetHttpClient();
         var recipe1 = new UpsertRecipe
@@ -189,12 +189,12 @@ public class RecipeIntegrationTests
         await PostRecipeAsync(client, recipe1);
         var (id2, _) = await PostRecipeAsync(client, recipe2);
 
-        // Try to rename recipe2 to recipe1's title - should be 422
+        // Try to rename recipe2 to recipe1's title - should be 409
         recipe2.Title = recipeTitle1;
         using var requestContent = new StringContent(JsonSerializer.Serialize(recipe2), Encoding.UTF8, "application/json");
         using var response = await client.PutAsync($"/api/recipe/{id2}", requestContent);
 
-        await response.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+        await response.ShouldHaveStatusCode(HttpStatusCode.Conflict);
     }
 
     private static async Task<(int Id, string Title)> PostRecipeAsync(HttpClient client, UpsertRecipe recipe)

--- a/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
+++ b/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
@@ -171,13 +171,34 @@ public class RecipeApiTests
     }
 
     [Theory, CustomAutoData]
-    public async Task UpdateRecipeAsync_Success(RecipeId recipeId, UpsertRecipe upsertRecipe, RecipeDetail recipe)
+    public async Task UpdateRecipeAsync_Success(MenuUserId callerId, RecipeId recipeId, UpsertRecipe upsertRecipe, RecipeDetail recipe)
     {
+        A.CallTo(() => recipeService.UpdateRecipeAsync(recipeId, upsertRecipe, callerId)).Returns(true);
         A.CallTo(() => recipeService.GetRecipeAsync(recipeId)).Returns(recipe);
 
-        var result = await RecipeApi.UpdateRecipeAsync(recipeService, recipeId, upsertRecipe);
+        var result = await RecipeApi.UpdateRecipeAsync(recipeService, CreateHttpContext(callerId), recipeId, upsertRecipe);
 
-        A.CallTo(() => recipeService.UpdateRecipeAsync(recipeId, upsertRecipe)).MustHaveHappenedOnceExactly();
-        result.Should().Be(recipe);
+        A.CallTo(() => recipeService.UpdateRecipeAsync(recipeId, upsertRecipe, callerId)).MustHaveHappenedOnceExactly();
+        var okResult = result.Should().BeOfType<Ok<RecipeDetail>>().Subject;
+        okResult.Value.Should().Be(recipe);
+    }
+
+    [Theory, CustomAutoData]
+    public async Task UpdateRecipeAsync_NotFound_Returns404(MenuUserId callerId, RecipeId recipeId, UpsertRecipe upsertRecipe)
+    {
+        A.CallTo(() => recipeService.UpdateRecipeAsync(recipeId, upsertRecipe, callerId)).Returns(false);
+
+        var result = await RecipeApi.UpdateRecipeAsync(recipeService, CreateHttpContext(callerId), recipeId, upsertRecipe);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(404);
+    }
+
+    [Theory, CustomAutoData]
+    public async Task UpdateRecipeAsync_NoMenuUserId_Returns401(RecipeId recipeId, UpsertRecipe upsertRecipe)
+    {
+        var result = await RecipeApi.UpdateRecipeAsync(recipeService, CreateHttpContext(null), recipeId, upsertRecipe);
+
+        result.Should().BeOfType<UnauthorizedHttpResult>();
     }
 }

--- a/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using FakeItEasy;
 using MenuDB;
+using MenuApi.Exceptions;
 using MenuApi.Repositories;
 using MenuApi.Services;
 using MenuApi.ValueObjects;
@@ -129,23 +130,53 @@ public class RecipeServiceTests
             r => r.Title == upsertRecipe.Title && r.AccessScope == upsertRecipe.AccessScope && r.OwnerUserId == callerId)))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(recipeId, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => recipeStepRepository.UpsertStepCollectionAsync(recipeId, A<IEnumerable<DBModel.RecipeStep>>._)).MustHaveHappenedOnceExactly();
     }
 
     [Theory, CustomAutoData]
-    public async Task UpdateRecipeSuccess(RecipeId recipeId, UpsertRecipe upsertRecipe)
+    public async Task UpdateRecipeSuccess(RecipeId recipeId, MenuUserId callerId, UpsertRecipe upsertRecipe, DBModel.Recipe existingRecipe)
     {
-        await sut.UpdateRecipeAsync(recipeId, upsertRecipe);
+        existingRecipe = existingRecipe with { OwnerUserId = callerId };
+        A.CallTo(() => recipeRepository.GetRecipeAsync(recipeId)).Returns(existingRecipe);
 
+        var result = await sut.UpdateRecipeAsync(recipeId, upsertRecipe, callerId);
+
+        result.Should().BeTrue();
         A.CallTo(() => recipeRepository.UpdateRecipeAsync(recipeId, A<DBModel.Recipe>.That.Matches(
             r => r.Title == upsertRecipe.Title && r.AccessScope == upsertRecipe.AccessScope)))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => recipeRepository.UpsertRecipeIngredientsAsync(recipeId, A<IEnumerable<DBModel.RecipeIngredient>>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => recipeStepRepository.UpsertStepCollectionAsync(recipeId, A<IEnumerable<DBModel.RecipeStep>>._)).MustHaveHappenedOnceExactly();
     }
 
     [Theory, CustomAutoData]
-    public async Task UpdateRecipe_Should_Throw_Exception_For_null_upsertRecipeAsync(RecipeId recipeId)
+    public async Task UpdateRecipe_RecipeNotFound_ReturnsFalse(RecipeId recipeId, MenuUserId callerId, UpsertRecipe upsertRecipe)
     {
-        Func<Task> fun = () => sut.UpdateRecipeAsync(recipeId, null!);
+        A.CallTo(() => recipeRepository.GetRecipeAsync(recipeId)).Returns((DBModel.Recipe?)null);
+
+        var result = await sut.UpdateRecipeAsync(recipeId, upsertRecipe, callerId);
+
+        result.Should().BeFalse();
+        A.CallTo(() => recipeRepository.UpdateRecipeAsync(recipeId, A<DBModel.Recipe>._)).MustNotHaveHappened();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task UpdateRecipe_CallerIsNotOwner_ThrowsForbiddenAccessException(
+        RecipeId recipeId, MenuUserId callerId, MenuUserId ownerId, UpsertRecipe upsertRecipe, DBModel.Recipe existingRecipe)
+    {
+        existingRecipe = existingRecipe with { OwnerUserId = ownerId };
+        A.CallTo(() => recipeRepository.GetRecipeAsync(recipeId)).Returns(existingRecipe);
+
+        Func<Task> fun = () => sut.UpdateRecipeAsync(recipeId, upsertRecipe, callerId);
+
+        await fun.Should().ThrowAsync<ForbiddenAccessException>();
+        A.CallTo(() => recipeRepository.UpdateRecipeAsync(recipeId, A<DBModel.Recipe>._)).MustNotHaveHappened();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task UpdateRecipe_Should_Throw_Exception_For_null_upsertRecipeAsync(RecipeId recipeId, MenuUserId callerId)
+    {
+        Func<Task> fun = () => sut.UpdateRecipeAsync(recipeId, null!, callerId);
 
         var result = await fun.Should().ThrowAsync<ArgumentNullException>();
         result.And.ParamName.Should().Be("upsertRecipe");

--- a/backend/MenuApi.Tests/Validation/UpsertRecipeValidatorTests.cs
+++ b/backend/MenuApi.Tests/Validation/UpsertRecipeValidatorTests.cs
@@ -49,9 +49,25 @@ public class UpsertRecipeValidatorTests
     }
 
     [Fact]
-    public void EmptyIngredients_Fails()
+    public void EmptyIngredients_Passes()
     {
         var recipe = CreateValidRecipe(ingredients: []);
+
+        var result = validator.TestValidate(recipe);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Ingredients);
+    }
+
+    [Fact]
+    public void NullIngredients_Fails()
+    {
+        var recipe = new UpsertRecipe
+        {
+            Title = RecipeTitle.From("Test Recipe"),
+            AccessScope = RecipeAccessScope.Private,
+            Ingredients = null!,
+            Steps = [],
+        };
 
         var result = validator.TestValidate(recipe);
 

--- a/backend/MenuApi/Exceptions/BusinessValidationExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/BusinessValidationExceptionHandler.cs
@@ -1,29 +1,10 @@
-using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.AspNetCore.Mvc;
-
 namespace MenuApi.Exceptions;
 
-public class BusinessValidationExceptionHandler : IExceptionHandler
+public class BusinessValidationExceptionHandler : ProblemDetailsExceptionHandler<BusinessValidationException>
 {
-    public async ValueTask<bool> TryHandleAsync(
-        HttpContext httpContext,
-        Exception exception,
-        CancellationToken cancellationToken)
-    {
-        if (exception is not BusinessValidationException bve)
-            return false;
+    protected override int StatusCode => StatusCodes.Status422UnprocessableEntity;
 
-        httpContext.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
-        httpContext.Response.ContentType = "application/problem+json";
+    protected override string Title => "Unprocessable Entity";
 
-        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
-        {
-            Status = StatusCodes.Status422UnprocessableEntity,
-            Title = "Unprocessable Entity",
-            Detail = bve.Message,
-            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.21"
-        }, cancellationToken);
-
-        return true;
-    }
+    protected override string Type => "https://tools.ietf.org/html/rfc9110#section-15.5.21";
 }

--- a/backend/MenuApi/Exceptions/ConflictException.cs
+++ b/backend/MenuApi/Exceptions/ConflictException.cs
@@ -1,0 +1,6 @@
+namespace MenuApi.Exceptions;
+
+public class ConflictException : Exception
+{
+    public ConflictException(string message) : base(message) { }
+}

--- a/backend/MenuApi/Exceptions/ConflictExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/ConflictExceptionHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MenuApi.Exceptions;
+
+public class ConflictExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not ConflictException ce)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
+        httpContext.Response.ContentType = "application/problem+json";
+
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status409Conflict,
+            Title = "Conflict",
+            Detail = ce.Message,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.10"
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/MenuApi/Exceptions/ConflictExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/ConflictExceptionHandler.cs
@@ -1,29 +1,10 @@
-using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.AspNetCore.Mvc;
-
 namespace MenuApi.Exceptions;
 
-public class ConflictExceptionHandler : IExceptionHandler
+public class ConflictExceptionHandler : ProblemDetailsExceptionHandler<ConflictException>
 {
-    public async ValueTask<bool> TryHandleAsync(
-        HttpContext httpContext,
-        Exception exception,
-        CancellationToken cancellationToken)
-    {
-        if (exception is not ConflictException ce)
-            return false;
+    protected override int StatusCode => StatusCodes.Status409Conflict;
 
-        httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
-        httpContext.Response.ContentType = "application/problem+json";
+    protected override string Title => "Conflict";
 
-        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
-        {
-            Status = StatusCodes.Status409Conflict,
-            Title = "Conflict",
-            Detail = ce.Message,
-            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.10"
-        }, cancellationToken);
-
-        return true;
-    }
+    protected override string Type => "https://tools.ietf.org/html/rfc9110#section-15.5.10";
 }

--- a/backend/MenuApi/Exceptions/ForbiddenAccessException.cs
+++ b/backend/MenuApi/Exceptions/ForbiddenAccessException.cs
@@ -1,0 +1,6 @@
+namespace MenuApi.Exceptions;
+
+public class ForbiddenAccessException : Exception
+{
+    public ForbiddenAccessException(string message) : base(message) { }
+}

--- a/backend/MenuApi/Exceptions/ForbiddenAccessExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/ForbiddenAccessExceptionHandler.cs
@@ -1,29 +1,10 @@
-using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.AspNetCore.Mvc;
-
 namespace MenuApi.Exceptions;
 
-public class ForbiddenAccessExceptionHandler : IExceptionHandler
+public class ForbiddenAccessExceptionHandler : ProblemDetailsExceptionHandler<ForbiddenAccessException>
 {
-    public async ValueTask<bool> TryHandleAsync(
-        HttpContext httpContext,
-        Exception exception,
-        CancellationToken cancellationToken)
-    {
-        if (exception is not ForbiddenAccessException fae)
-            return false;
+    protected override int StatusCode => StatusCodes.Status403Forbidden;
 
-        httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
-        httpContext.Response.ContentType = "application/problem+json";
+    protected override string Title => "Forbidden";
 
-        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
-        {
-            Status = StatusCodes.Status403Forbidden,
-            Title = "Forbidden",
-            Detail = fae.Message,
-            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.4"
-        }, cancellationToken);
-
-        return true;
-    }
+    protected override string Type => "https://tools.ietf.org/html/rfc9110#section-15.5.4";
 }

--- a/backend/MenuApi/Exceptions/ForbiddenAccessExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/ForbiddenAccessExceptionHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MenuApi.Exceptions;
+
+public class ForbiddenAccessExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not ForbiddenAccessException fae)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+        httpContext.Response.ContentType = "application/problem+json";
+
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status403Forbidden,
+            Title = "Forbidden",
+            Detail = fae.Message,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.4"
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/MenuApi/Exceptions/ProblemDetailsExceptionHandler.cs
+++ b/backend/MenuApi/Exceptions/ProblemDetailsExceptionHandler.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MenuApi.Exceptions;
+
+public abstract class ProblemDetailsExceptionHandler<TException> : IExceptionHandler
+    where TException : Exception
+{
+    protected abstract int StatusCode { get; }
+
+    protected abstract string Title { get; }
+
+    protected abstract string Type { get; }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not TException typedException)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCode;
+        httpContext.Response.ContentType = "application/problem+json";
+
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCode,
+            Title = Title,
+            Detail = typedException.Message,
+            Type = Type
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/MenuApi/Program.cs
+++ b/backend/MenuApi/Program.cs
@@ -29,6 +29,8 @@ builder.Services.AddTransient<IMenuUserRepository, MenuUserRepository>();
 builder.Services.AddTransient<IMenuUserService, MenuUserService>();
 
 builder.Services.AddExceptionHandler<BusinessValidationExceptionHandler>();
+builder.Services.AddExceptionHandler<ConflictExceptionHandler>();
+builder.Services.AddExceptionHandler<ForbiddenAccessExceptionHandler>();
 
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 

--- a/backend/MenuApi/Recipes/RecipeApi.cs
+++ b/backend/MenuApi/Recipes/RecipeApi.cs
@@ -33,14 +33,17 @@ public static class RecipeApi
             .AddEndpointFilter<ValidationFilter<UpsertRecipe>>()
             .Produces<RecipeDetail>(StatusCodes.Status200OK)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
-            .Produces(StatusCodes.Status401Unauthorized);
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status409Conflict);
 
         group.MapPut("{recipeId}", UpdateRecipeAsync)
             .AddEndpointFilter<ValidationFilter<UpsertRecipe>>()
             .Produces<RecipeDetail>(StatusCodes.Status200OK)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
 
         return group;
     }
@@ -116,10 +119,22 @@ public static class RecipeApi
         return Results.Ok(recipe ?? throw new InvalidOperationException("Recipe creation failed"));
     }
 
-    public static async Task<RecipeDetail> UpdateRecipeAsync(IRecipeService recipeService, RecipeId recipeId, UpsertRecipe upsertRecipe)
+    public static async Task<IResult> UpdateRecipeAsync(IRecipeService recipeService, HttpContext httpContext, RecipeId recipeId, UpsertRecipe upsertRecipe)
     {
-        await recipeService.UpdateRecipeAsync(recipeId, upsertRecipe);
+        if (httpContext.Items[MenuUserHttpContextKeys.MenuUserId] is not MenuUserId callerId)
+        {
+            return Results.Unauthorized();
+        }
+
+        var updated = await recipeService.UpdateRecipeAsync(recipeId, upsertRecipe, callerId);
+        if (!updated)
+        {
+            return Results.Problem(
+                detail: $"Recipe with ID {recipeId} was not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
         var recipe = await recipeService.GetRecipeAsync(recipeId);
-        return recipe ?? throw new InvalidOperationException($"Failed to retrieve the updated recipe with ID {recipeId} after the update operation.");
+        return Results.Ok(recipe ?? throw new InvalidOperationException($"Failed to retrieve the updated recipe with ID {recipeId} after the update operation."));
     }
 }

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -24,7 +24,22 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
         return await query
             .OrderByDescending(r => r.UpdatedAtUtc)
             .Take(take)
-            .Select(r => MapToDbModel(r))
+            .Select(r => new DBModel.Recipe
+            {
+                Id = RecipeId.From(r.Id),
+                Title = RecipeTitle.From(r.Title),
+                AccessScope = r.AccessScope,
+                OwnerUserId = r.OwnerUserId == null ? null : MenuUserId.From(r.OwnerUserId.Value),
+                Summary = r.Summary,
+                Servings = r.Servings,
+                YieldText = r.YieldText,
+                PrepTimeMinutes = r.PrepTimeMinutes,
+                CookTimeMinutes = r.CookTimeMinutes,
+                TotalTimeMinutes = r.TotalTimeMinutes,
+                CreatedAtUtc = r.CreatedAtUtc,
+                UpdatedAtUtc = r.UpdatedAtUtc,
+            })
+            .AsNoTracking()
             .ToListAsync()
             .ConfigureAwait(false);
     }
@@ -33,7 +48,22 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
     {
         return await db.Recipes
             .Where(r => r.Id == recipeId.Value)
-            .Select(r => MapToDbModel(r))
+            .Select(r => new DBModel.Recipe
+            {
+                Id = RecipeId.From(r.Id),
+                Title = RecipeTitle.From(r.Title),
+                AccessScope = r.AccessScope,
+                OwnerUserId = r.OwnerUserId == null ? null : MenuUserId.From(r.OwnerUserId.Value),
+                Summary = r.Summary,
+                Servings = r.Servings,
+                YieldText = r.YieldText,
+                PrepTimeMinutes = r.PrepTimeMinutes,
+                CookTimeMinutes = r.CookTimeMinutes,
+                TotalTimeMinutes = r.TotalTimeMinutes,
+                CreatedAtUtc = r.CreatedAtUtc,
+                UpdatedAtUtc = r.UpdatedAtUtc,
+            })
+            .AsNoTracking()
             .FirstOrDefaultAsync()
             .ConfigureAwait(false);
     }
@@ -83,7 +113,7 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
         }
         catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
         {
-            throw new BusinessValidationException($"A recipe titled '{recipe.Title.Value}' already exists.");
+            throw new ConflictException($"A recipe titled '{recipe.Title.Value}' already exists.");
         }
 
         return RecipeId.From(entity.Id);
@@ -141,23 +171,7 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
         }
         catch (SqlException ex) when (ex.IsUniqueConstraintViolation())
         {
-            throw new BusinessValidationException($"A recipe titled '{recipe.Title.Value}' already exists.");
+            throw new ConflictException($"A recipe titled '{recipe.Title.Value}' already exists.");
         }
     }
-
-    private static DBModel.Recipe MapToDbModel(RecipeEntity r) => new()
-    {
-        Id = RecipeId.From(r.Id),
-        Title = RecipeTitle.From(r.Title),
-        AccessScope = r.AccessScope,
-        OwnerUserId = r.OwnerUserId.HasValue ? MenuUserId.From(r.OwnerUserId.Value) : null,
-        Summary = r.Summary,
-        Servings = r.Servings,
-        YieldText = r.YieldText,
-        PrepTimeMinutes = r.PrepTimeMinutes,
-        CookTimeMinutes = r.CookTimeMinutes,
-        TotalTimeMinutes = r.TotalTimeMinutes,
-        CreatedAtUtc = r.CreatedAtUtc,
-        UpdatedAtUtc = r.UpdatedAtUtc,
-    };
 }

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using MenuDB;
 using MenuDB.Data;
 using MenuApi.DBModel;
@@ -12,6 +13,24 @@ namespace MenuApi.Repositories;
 [ExcludeFromCodeCoverage]
 public class RecipeRepository(MenuDbContext db) : IRecipeRepository
 {
+    // Kept as an Expression (not a method) so EF Core can translate it inside .Select - a compiled
+    // method call there isn't translatable and forces client-side evaluation of a tracked entity.
+    private static readonly Expression<Func<RecipeEntity, DBModel.Recipe>> ToDbModel = r => new DBModel.Recipe
+    {
+        Id = RecipeId.From(r.Id),
+        Title = RecipeTitle.From(r.Title),
+        AccessScope = r.AccessScope,
+        OwnerUserId = r.OwnerUserId == null ? null : MenuUserId.From(r.OwnerUserId.Value),
+        Summary = r.Summary,
+        Servings = r.Servings,
+        YieldText = r.YieldText,
+        PrepTimeMinutes = r.PrepTimeMinutes,
+        CookTimeMinutes = r.CookTimeMinutes,
+        TotalTimeMinutes = r.TotalTimeMinutes,
+        CreatedAtUtc = r.CreatedAtUtc,
+        UpdatedAtUtc = r.UpdatedAtUtc,
+    };
+
     public async Task<IEnumerable<DBModel.Recipe>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take)
     {
         var query = scope switch
@@ -24,21 +43,7 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
         return await query
             .OrderByDescending(r => r.UpdatedAtUtc)
             .Take(take)
-            .Select(r => new DBModel.Recipe
-            {
-                Id = RecipeId.From(r.Id),
-                Title = RecipeTitle.From(r.Title),
-                AccessScope = r.AccessScope,
-                OwnerUserId = r.OwnerUserId == null ? null : MenuUserId.From(r.OwnerUserId.Value),
-                Summary = r.Summary,
-                Servings = r.Servings,
-                YieldText = r.YieldText,
-                PrepTimeMinutes = r.PrepTimeMinutes,
-                CookTimeMinutes = r.CookTimeMinutes,
-                TotalTimeMinutes = r.TotalTimeMinutes,
-                CreatedAtUtc = r.CreatedAtUtc,
-                UpdatedAtUtc = r.UpdatedAtUtc,
-            })
+            .Select(ToDbModel)
             .AsNoTracking()
             .ToListAsync()
             .ConfigureAwait(false);
@@ -48,21 +53,7 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
     {
         return await db.Recipes
             .Where(r => r.Id == recipeId.Value)
-            .Select(r => new DBModel.Recipe
-            {
-                Id = RecipeId.From(r.Id),
-                Title = RecipeTitle.From(r.Title),
-                AccessScope = r.AccessScope,
-                OwnerUserId = r.OwnerUserId == null ? null : MenuUserId.From(r.OwnerUserId.Value),
-                Summary = r.Summary,
-                Servings = r.Servings,
-                YieldText = r.YieldText,
-                PrepTimeMinutes = r.PrepTimeMinutes,
-                CookTimeMinutes = r.CookTimeMinutes,
-                TotalTimeMinutes = r.TotalTimeMinutes,
-                CreatedAtUtc = r.CreatedAtUtc,
-                UpdatedAtUtc = r.UpdatedAtUtc,
-            })
+            .Select(ToDbModel)
             .AsNoTracking()
             .FirstOrDefaultAsync()
             .ConfigureAwait(false);

--- a/backend/MenuApi/Services/IRecipeService.cs
+++ b/backend/MenuApi/Services/IRecipeService.cs
@@ -13,5 +13,5 @@ public interface IRecipeService
 
     Task<IEnumerable<RecipeListItem>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take);
 
-    Task UpdateRecipeAsync(RecipeId recipeId, UpsertRecipe upsertRecipe);
+    Task<bool> UpdateRecipeAsync(RecipeId recipeId, UpsertRecipe upsertRecipe, MenuUserId callerId);
 }

--- a/backend/MenuApi/Services/RecipeService.cs
+++ b/backend/MenuApi/Services/RecipeService.cs
@@ -1,4 +1,5 @@
 using MenuDB;
+using MenuApi.Exceptions;
 using MenuApi.MappingProfiles;
 using MenuApi.Repositories;
 using MenuApi.ValueObjects;
@@ -50,14 +51,26 @@ public class RecipeService(IRecipeRepository recipeRepository, IRecipeStepReposi
             await using var tran = await db.Database.BeginTransactionAsync().ConfigureAwait(false);
             var recipeId = await recipeRepository.CreateRecipeAsync(recipe).ConfigureAwait(false);
             await recipeRepository.UpsertRecipeIngredientsAsync(recipeId, ViewModelMapper.Map(upsertRecipe.Ingredients)).ConfigureAwait(false);
+            await recipeStepRepository.UpsertStepCollectionAsync(recipeId, ViewModelMapper.Map(upsertRecipe.Steps)).ConfigureAwait(false);
             await tran.CommitAsync().ConfigureAwait(false);
             return recipeId;
         }).ConfigureAwait(false);
     }
 
-    public async Task UpdateRecipeAsync(RecipeId recipeId, UpsertRecipe upsertRecipe)
+    public async Task<bool> UpdateRecipeAsync(RecipeId recipeId, UpsertRecipe upsertRecipe, MenuUserId callerId)
     {
         ArgumentNullException.ThrowIfNull(upsertRecipe);
+
+        var existing = await recipeRepository.GetRecipeAsync(recipeId).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        if (existing.OwnerUserId != callerId)
+        {
+            throw new ForbiddenAccessException($"You do not own recipe {recipeId}.");
+        }
 
         var strategy = db.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
@@ -65,7 +78,10 @@ public class RecipeService(IRecipeRepository recipeRepository, IRecipeStepReposi
             await using var tran = await db.Database.BeginTransactionAsync().ConfigureAwait(false);
             await recipeRepository.UpdateRecipeAsync(recipeId, ViewModelMapper.Map(upsertRecipe)).ConfigureAwait(false);
             await recipeRepository.UpsertRecipeIngredientsAsync(recipeId, ViewModelMapper.Map(upsertRecipe.Ingredients)).ConfigureAwait(false);
+            await recipeStepRepository.UpsertStepCollectionAsync(recipeId, ViewModelMapper.Map(upsertRecipe.Steps)).ConfigureAwait(false);
             await tran.CommitAsync().ConfigureAwait(false);
         }).ConfigureAwait(false);
+
+        return true;
     }
 }

--- a/backend/MenuApi/Validation/UpsertRecipeValidator.cs
+++ b/backend/MenuApi/Validation/UpsertRecipeValidator.cs
@@ -19,12 +19,7 @@ public class UpsertRecipeValidator : AbstractValidator<UpsertRecipe>
 
         RuleFor(x => x.Ingredients)
             .NotNull()
-            .WithMessage("'Ingredients' must not be empty.");
-
-        RuleFor(x => x.Ingredients)
-            .Must(i => i is { Count: > 0 })
-            .When(x => x.Ingredients is not null)
-            .WithMessage("'Ingredients' must not be empty.");
+            .WithMessage("'Ingredients' must not be null.");
 
         RuleForEach(x => x.Ingredients)
             .SetValidator(new RecipeIngredientItemValidator());


### PR DESCRIPTION
## Summary
- `POST`/`PUT` now accept ingredients **and** steps together, persisted in a single transaction (steps were plumbed by Epic #1098 but never wired into create/update).
- `PUT` now checks ownership: 403 for non-owners, 404 for a missing recipe.
- Duplicate `(OwnerUserId, Title)` now returns 409 (was 422) via a new `ConflictException`/handler; a new `ForbiddenAccessException`/handler backs the 403.
- `UpsertRecipeValidator` now accepts an empty ingredient list (zero ingredients/steps is a valid minimal recipe).

Also fixes a real stale-read bug found while wiring the ownership check: `RecipeRepository.GetRecipeAsync`/`GetRecipesAsync` called a private mapping method *inside* a LINQ `Select`, which isn't EF-translatable — EF had to materialize (and, with nothing suppressing tracking, track) a full `RecipeEntity` to run it. Once the new pre-update ownership check added a read before the write, that tracked entity went stale the moment `ExecuteUpdateAsync` wrote past the change tracker, and the post-update read-for-response reused the stale tracked instance via EF's identity resolution instead of the freshly committed row — title/scalar updates were silently reverting in the response (ingredients/steps updated fine). Fixed by inlining the projection with `.AsNoTracking()`.

Closes #1116
Part of #1099

## Test plan
- [x] `dotnet test MenuApi.Tests` (unit)
- [x] `dotnet test MenuApi.Integration.Tests` — create/update with ingredients+steps, non-owner 403, duplicate-title 409 (both create and update paths)