### PR TITLE
Add recipe delete endpoint

### DIFF
--- a/backend/MenuApi.Integration.Tests/Factory/TestDatabaseSeeder.cs
+++ b/backend/MenuApi.Integration.Tests/Factory/TestDatabaseSeeder.cs
@@ -56,6 +56,16 @@ internal static class TestDatabaseSeeder
         return entity.Id;
     }
 
+    public static async Task<int> CountStepsForRecipeAsync(
+        ApiTestFixture fixture,
+        int recipeId,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await CreateDbContextAsync(fixture, cancellationToken);
+
+        return await db.RecipeSteps.CountAsync(s => s.RecipeId == recipeId, cancellationToken);
+    }
+
     private static async Task<MenuDbContext> CreateDbContextAsync(ApiTestFixture fixture, CancellationToken cancellationToken)
     {
         var connectionString = await fixture.app.GetConnectionStringAsync("menu", cancellationToken);

--- a/backend/MenuApi.Integration.Tests/RecipeDeleteIntegrationTests.cs
+++ b/backend/MenuApi.Integration.Tests/RecipeDeleteIntegrationTests.cs
@@ -1,0 +1,84 @@
+using AwesomeAssertions;
+using MenuApi.Integration.Tests.Factory;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace MenuApi.Integration.Tests;
+
+[Collection("API Host Collection")]
+public class RecipeDeleteIntegrationTests
+{
+    private readonly JsonSerializerOptions jsonOptions;
+    private readonly ApiTestFixture fixture;
+
+    public RecipeDeleteIntegrationTests(ApiTestFixture fixture)
+    {
+        jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        this.fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("Recipe To Delete")]
+    public async Task Delete_Recipe_As_Owner_Succeeds_And_Cascades(string recipeTitle)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = await fixture.GetHttpClient();
+
+        var body = new
+        {
+            Title = recipeTitle,
+            AccessScope = "Private",
+            Ingredients = new[] { new { SortOrder = 0, IngredientText = "Flour", MeasureText = "200g", IsOptional = false } },
+            Steps = new[] { new { SortOrder = 0, InstructionText = "Mix well." } },
+        };
+        using var createContent = new StringContent(JsonSerializer.Serialize(body, jsonOptions), Encoding.UTF8, "application/json");
+        using var createResponse = await client.PostAsync("/api/recipe", createContent);
+        await createResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        using var createStream = await createResponse.Content.ReadAsStreamAsync();
+        using var createDoc = await JsonDocument.ParseAsync(createStream);
+        var recipeId = createDoc.RootElement.GetProperty("id").GetInt32();
+
+        using var deleteResponse = await client.DeleteAsync($"/api/recipe/{recipeId}");
+        await deleteResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        using var getResponse = await client.GetAsync($"/api/recipe/{recipeId}");
+        await getResponse.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+
+        using var ingredientResponse = await client.GetAsync($"/api/recipe/{recipeId}/ingredient");
+        await ingredientResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+        var ingredientData = await ingredientResponse.Content.ReadAsStringAsync();
+        using var ingredientDoc = JsonDocument.Parse(ingredientData);
+        ingredientDoc.RootElement.GetArrayLength().Should().Be(0);
+
+        var stepCount = await TestDatabaseSeeder.CountStepsForRecipeAsync(fixture, recipeId, cancellationToken);
+        stepCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_Recipe_NotOwner_Returns403()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = await fixture.GetHttpClient();
+
+        var otherOwnerId = await TestDatabaseSeeder.AddMenuUserAsync(fixture, $"other-user-{Guid.NewGuid()}", cancellationToken);
+        var recipeId = await TestDatabaseSeeder.AddRecipeAsync(
+            fixture, $"Someone Else's Recipe {Guid.NewGuid()}", otherOwnerId, "Private", cancellationToken);
+
+        using var response = await client.DeleteAsync($"/api/recipe/{recipeId}");
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Delete_Recipe_NotFound_Returns404()
+    {
+        using var client = await fixture.GetHttpClient();
+
+        using var response = await client.DeleteAsync("/api/recipe/999999999");
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+    }
+}

--- a/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
+++ b/backend/MenuApi.Tests/Controllers/RecipeApiTests.cs
@@ -201,4 +201,34 @@ public class RecipeApiTests
 
         result.Should().BeOfType<UnauthorizedHttpResult>();
     }
+
+    [Theory, CustomAutoData]
+    public async Task DeleteRecipeAsync_Success(MenuUserId callerId, RecipeId recipeId)
+    {
+        A.CallTo(() => recipeService.DeleteRecipeAsync(recipeId, callerId)).Returns(true);
+
+        var result = await RecipeApi.DeleteRecipeAsync(recipeService, CreateHttpContext(callerId), recipeId);
+
+        A.CallTo(() => recipeService.DeleteRecipeAsync(recipeId, callerId)).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<NoContent>();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task DeleteRecipeAsync_NotFound_Returns404(MenuUserId callerId, RecipeId recipeId)
+    {
+        A.CallTo(() => recipeService.DeleteRecipeAsync(recipeId, callerId)).Returns(false);
+
+        var result = await RecipeApi.DeleteRecipeAsync(recipeService, CreateHttpContext(callerId), recipeId);
+
+        var problemResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(404);
+    }
+
+    [Theory, CustomAutoData]
+    public async Task DeleteRecipeAsync_NoMenuUserId_Returns401(RecipeId recipeId)
+    {
+        var result = await RecipeApi.DeleteRecipeAsync(recipeService, CreateHttpContext(null), recipeId);
+
+        result.Should().BeOfType<UnauthorizedHttpResult>();
+    }
 }

--- a/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
+++ b/backend/MenuApi.Tests/Services/RecipeServiceTests.cs
@@ -181,4 +181,40 @@ public class RecipeServiceTests
         var result = await fun.Should().ThrowAsync<ArgumentNullException>();
         result.And.ParamName.Should().Be("upsertRecipe");
     }
+
+    [Theory, CustomAutoData]
+    public async Task DeleteRecipeSuccess(RecipeId recipeId, MenuUserId callerId, DBModel.Recipe existingRecipe)
+    {
+        existingRecipe = existingRecipe with { OwnerUserId = callerId };
+        A.CallTo(() => recipeRepository.GetRecipeAsync(recipeId)).Returns(existingRecipe);
+
+        var result = await sut.DeleteRecipeAsync(recipeId, callerId);
+
+        result.Should().BeTrue();
+        A.CallTo(() => recipeRepository.DeleteRecipeAsync(recipeId)).MustHaveHappenedOnceExactly();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task DeleteRecipe_RecipeNotFound_ReturnsFalse(RecipeId recipeId, MenuUserId callerId)
+    {
+        A.CallTo(() => recipeRepository.GetRecipeAsync(recipeId)).Returns((DBModel.Recipe?)null);
+
+        var result = await sut.DeleteRecipeAsync(recipeId, callerId);
+
+        result.Should().BeFalse();
+        A.CallTo(() => recipeRepository.DeleteRecipeAsync(recipeId)).MustNotHaveHappened();
+    }
+
+    [Theory, CustomAutoData]
+    public async Task DeleteRecipe_CallerIsNotOwner_ThrowsForbiddenAccessException(
+        RecipeId recipeId, MenuUserId callerId, MenuUserId ownerId, DBModel.Recipe existingRecipe)
+    {
+        existingRecipe = existingRecipe with { OwnerUserId = ownerId };
+        A.CallTo(() => recipeRepository.GetRecipeAsync(recipeId)).Returns(existingRecipe);
+
+        Func<Task> fun = () => sut.DeleteRecipeAsync(recipeId, callerId);
+
+        await fun.Should().ThrowAsync<ForbiddenAccessException>();
+        A.CallTo(() => recipeRepository.DeleteRecipeAsync(recipeId)).MustNotHaveHappened();
+    }
 }

--- a/backend/MenuApi/Recipes/RecipeApi.cs
+++ b/backend/MenuApi/Recipes/RecipeApi.cs
@@ -45,6 +45,12 @@ public static class RecipeApi
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
+        group.MapDelete("{recipeId}", DeleteRecipeAsync)
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return group;
     }
 
@@ -136,5 +142,23 @@ public static class RecipeApi
 
         var recipe = await recipeService.GetRecipeAsync(recipeId);
         return Results.Ok(recipe ?? throw new InvalidOperationException($"Failed to retrieve the updated recipe with ID {recipeId} after the update operation."));
+    }
+
+    public static async Task<IResult> DeleteRecipeAsync(IRecipeService recipeService, HttpContext httpContext, RecipeId recipeId)
+    {
+        if (httpContext.Items[MenuUserHttpContextKeys.MenuUserId] is not MenuUserId callerId)
+        {
+            return Results.Unauthorized();
+        }
+
+        var deleted = await recipeService.DeleteRecipeAsync(recipeId, callerId);
+        if (!deleted)
+        {
+            return Results.Problem(
+                detail: $"Recipe with ID {recipeId} was not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return Results.NoContent();
     }
 }

--- a/backend/MenuApi/Repositories/IRecipeRepository.cs
+++ b/backend/MenuApi/Repositories/IRecipeRepository.cs
@@ -15,4 +15,6 @@ public interface IRecipeRepository
     Task<IEnumerable<DBModel.Recipe>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take);
 
     Task UpdateRecipeAsync(RecipeId recipeId, DBModel.Recipe recipe);
+
+    Task DeleteRecipeAsync(RecipeId recipeId);
 }

--- a/backend/MenuApi/Repositories/RecipeRepository.cs
+++ b/backend/MenuApi/Repositories/RecipeRepository.cs
@@ -165,4 +165,12 @@ public class RecipeRepository(MenuDbContext db) : IRecipeRepository
             throw new ConflictException($"A recipe titled '{recipe.Title.Value}' already exists.");
         }
     }
+
+    public async Task DeleteRecipeAsync(RecipeId recipeId)
+    {
+        await db.Recipes
+            .Where(r => r.Id == recipeId.Value)
+            .ExecuteDeleteAsync()
+            .ConfigureAwait(false);
+    }
 }

--- a/backend/MenuApi/Services/IRecipeService.cs
+++ b/backend/MenuApi/Services/IRecipeService.cs
@@ -14,4 +14,6 @@ public interface IRecipeService
     Task<IEnumerable<RecipeListItem>> GetRecipesAsync(RecipeListScope scope, MenuUserId callerId, int take);
 
     Task<bool> UpdateRecipeAsync(RecipeId recipeId, UpsertRecipe upsertRecipe, MenuUserId callerId);
+
+    Task<bool> DeleteRecipeAsync(RecipeId recipeId, MenuUserId callerId);
 }

--- a/backend/MenuApi/Services/RecipeService.cs
+++ b/backend/MenuApi/Services/RecipeService.cs
@@ -84,4 +84,22 @@ public class RecipeService(IRecipeRepository recipeRepository, IRecipeStepReposi
 
         return true;
     }
+
+    public async Task<bool> DeleteRecipeAsync(RecipeId recipeId, MenuUserId callerId)
+    {
+        var existing = await recipeRepository.GetRecipeAsync(recipeId).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        if (existing.OwnerUserId != callerId)
+        {
+            throw new ForbiddenAccessException($"You do not own recipe {recipeId}.");
+        }
+
+        await recipeRepository.DeleteRecipeAsync(recipeId).ConfigureAwait(false);
+
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- `DELETE /api/recipe/{recipeId}`, owner-only: 404 if missing, 403 if the caller isn't the owner, otherwise deletes via a single `ExecuteDeleteAsync` statement.
- `RecipeIngredient`/`RecipeStep` rows cascade via the FK constraints already configured with `DeleteBehavior.Cascade` in Epic #1098 — no `RecipeShare`/`RecipePublication`/etc. tables exist yet, consistent with epic #1099's own scope note that those are Epic 6 work.

Closes #1117
Part of #1099

## Test plan
- [x] `dotnet test MenuApi.Tests` (unit)
- [x] `dotnet test MenuApi.Integration.Tests` — owner delete (verifying both ingredient and step rows are actually gone, not just that the recipe 404s afterward), non-owner 403, missing-recipe 404