### PR TITLE
Expand recipe form with metadata fields and wire up submit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,8 @@ pnpm install              # Install dependencies
 pnpm dev                  # Dev server (standalone, port 5173)
 pnpm aspire               # Dev server started by Aspire (port 5173)
 pnpm build                # Type-check + production build
-pnpm test                 # Vitest unit tests
+pnpm test                 # Vitest: unit + Storybook projects
+pnpm test:unit            # Vitest unit tests only (jsdom)
 pnpm test:storybook       # Storybook interaction tests (run after any UI change)
 pnpm test:e2e             # Playwright end-to-end tests
 pnpm lint                 # ESLint
@@ -168,6 +169,18 @@ pnpm storybook            # Storybook dev server (port 6006)
 ```
 
 Always run `pnpm test:storybook` after making any change under `ui/menu-website/src/` — it catches regressions in components exercised by existing stories, not just changes to story files themselves.
+
+### Component Test Coverage
+
+Every Vue component that is added or changed must come with both:
+
+- **A co-located Storybook story** (`<component>.stories.ts`) covering the new/changed rendering and any client-side validation, with `play` interaction assertions.
+- **A co-located unit test** (`<component>.test.ts`) run by the `unit` Vitest project (jsdom + `@vue/test-utils`). Mount with `global: { plugins: [Quasar] }`; add `VueQueryPlugin` and a memory `vue-router` for components that use them.
+
+Split the two by what each can verify reliably:
+
+- Stories cover rendering, props and validation messages. Note that MSW request mocking is **not** currently reliable under `vitest --project=storybook` — handlers registered for `*/api/recipe` are not served, so the request fails at the network layer. Do not write a story that asserts on a mocked response body.
+- Unit tests cover request payloads, success/error branches and routing, by mocking `@/services/recipe-api` (the API layer) so the real service/TanStack Query wiring is still exercised. See `src/components/organisms/recipe/new-recipe-form.test.ts`.
 
 ### Style & Linting
 

--- a/ui/menu-website/.storybook/msw-handlers.ts
+++ b/ui/menu-website/.storybook/msw-handlers.ts
@@ -77,6 +77,16 @@ export const recipesLoadingHandler = http.get(recipePath, async () => {
   ]);
 });
 
+export const recipeCreateSuccessHandler = http.post(recipePath, async () => {
+  await delay(150);
+  return HttpResponse.json(sampleRecipeDetail, { status: 200 });
+});
+
+export const recipeCreateErrorHandler = http.post(recipePath, async () => {
+  await delay(150);
+  return HttpResponse.json({ title: 'Internal Server Error', status: 500 }, { status: 500 });
+});
+
 export const ingredientUnitsHandler = http.get(ingredientUnitsPath, () => {
   return HttpResponse.json([
     { id: 1, name: 'g' },

--- a/ui/menu-website/eslint.config.ts
+++ b/ui/menu-website/eslint.config.ts
@@ -55,7 +55,7 @@ export default defineConfigWithVueTs(
   pluginStorybook.configs['flat/addon-interactions'],
   {
     ...pluginVitest.configs.recommended,
-    files: ['src/**/__tests__/*'],
+    files: ['src/**/__tests__/*', 'src/**/*.test.ts'],
   },
 
   {

--- a/ui/menu-website/package.json
+++ b/ui/menu-website/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint . \"./src/**/*.{ts,js,cjs,mjs,vue}\"",
     "lint-fix": "eslint . \"./src/**/*.{ts,js,cjs,mjs,vue}\" --fix",
     "test": "vitest --passWithNoTests",
+    "test:unit": "vitest --project=unit --run",
     "test:e2e": "playwright test",
     "test:storybook": "vitest --project=storybook --run",
     "type-check": "vue-tsc --build --noEmit",

--- a/ui/menu-website/src/components/atoms/form/number-field.stories.ts
+++ b/ui/menu-website/src/components/atoms/form/number-field.stories.ts
@@ -1,0 +1,44 @@
+import preview from '@storybook-config/preview';
+import NumberField from './number-field.vue';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+const meta = preview.meta({
+  title: 'Atoms/Form/NumberField',
+  component: NumberField,
+  tags: ['autodocs'],
+  args: {
+    label: 'Number Field',
+    'onUpdate:modelValue': fn(),
+  },
+});
+
+export const Default = meta.story({
+  args: {},
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('spinbutton', { name: 'Number Field' });
+
+    await userEvent.type(input, '42');
+    await expect(args['onUpdate:modelValue']).toHaveBeenCalledWith(42);
+  },
+});
+
+export const Hint = meta.story({
+  args: {
+    hint: 'Enter a whole number.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Enter a whole number.')).toBeInTheDocument();
+  },
+});
+
+export const PreFilledValue = meta.story({
+  args: {
+    modelValue: 8,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByDisplayValue('8')).toBeInTheDocument();
+  },
+});

--- a/ui/menu-website/src/components/atoms/form/number-field.stories.ts
+++ b/ui/menu-website/src/components/atoms/form/number-field.stories.ts
@@ -42,3 +42,83 @@ export const PreFilledValue = meta.story({
     await expect(canvas.getByDisplayValue('8')).toBeInTheDocument();
   },
 });
+
+export const MinAndStep = meta.story({
+  args: {
+    min: 0,
+    step: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('spinbutton', { name: 'Number Field' });
+
+    await expect(input).toHaveAttribute('min', '0');
+    await expect(input).toHaveAttribute('step', '1');
+  },
+});
+
+export const ClearedValueEmitsNull = meta.story({
+  args: {
+    modelValue: 8,
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('spinbutton', { name: 'Number Field' });
+
+    await userEvent.clear(input);
+
+    await expect(args['onUpdate:modelValue']).toHaveBeenCalledWith(null);
+  },
+});
+
+const nonNegativeIntegerRules = [
+  (val: number | null) => val == null || Number.isInteger(val) || 'Must be a whole number',
+  (val: number | null) => val == null || val >= 0 || 'Must be 0 or greater',
+];
+
+export const RuleRejectsANegativeValue = meta.story({
+  args: {
+    rules: nonNegativeIntegerRules,
+    modelValue: -5,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Quasar validates on blur (and on model change), so focus then leave the field.
+    await userEvent.click(canvas.getByRole('spinbutton', { name: 'Number Field' }));
+    await userEvent.tab();
+
+    await expect(await canvas.findByText('Must be 0 or greater')).toBeInTheDocument();
+  },
+});
+
+export const RuleRejectsAFractionalValue = meta.story({
+  args: {
+    rules: nonNegativeIntegerRules,
+    modelValue: 3.5,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('spinbutton', { name: 'Number Field' }));
+    await userEvent.tab();
+
+    await expect(await canvas.findByText('Must be a whole number')).toBeInTheDocument();
+  },
+});
+
+export const RuleAcceptsAValidValue = meta.story({
+  args: {
+    rules: nonNegativeIntegerRules,
+    modelValue: 8,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('spinbutton', { name: 'Number Field' }));
+    await userEvent.tab();
+
+    await expect(canvas.queryByText('Must be 0 or greater')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Must be a whole number')).not.toBeInTheDocument();
+  },
+});

--- a/ui/menu-website/src/components/atoms/form/number-field.test.ts
+++ b/ui/menu-website/src/components/atoms/form/number-field.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { QInput, Quasar, type ValidationRule } from 'quasar';
+import { nextTick } from 'vue';
+import NumberField from './number-field.vue';
+
+const mountNumberField = (props: Record<string, unknown> = {}) =>
+  mount(NumberField, {
+    props: { label: 'Servings', ...props },
+    global: { plugins: [Quasar] },
+    attachTo: document.body,
+  });
+
+/** Emits from the inner q-input, which is what the browser feeds the component at runtime. */
+const emitFromInput = async (
+  wrapper: ReturnType<typeof mountNumberField>,
+  value: string | number | null,
+) => {
+  wrapper.findComponent(QInput).vm.$emit('update:model-value', value);
+  await nextTick();
+};
+
+describe('number-field', () => {
+  it('renders a numeric input with the supplied label', () => {
+    const wrapper = mountNumberField();
+
+    expect(wrapper.find('input').attributes('type')).toBe('number');
+    expect(wrapper.text()).toContain('Servings');
+  });
+
+  it('forwards min and step to the underlying input', () => {
+    const wrapper = mountNumberField({ min: 0, step: 1 });
+
+    const input = wrapper.find('input');
+    expect(input.attributes('min')).toBe('0');
+    expect(input.attributes('step')).toBe('1');
+  });
+
+  it('renders the hint when one is supplied', () => {
+    const wrapper = mountNumberField({ hint: 'Enter a whole number.' });
+
+    expect(wrapper.text()).toContain('Enter a whole number.');
+  });
+
+  it('displays a pre-filled model value', () => {
+    const wrapper = mountNumberField({ modelValue: 8 });
+
+    expect(wrapper.find('input').element.value).toBe('8');
+  });
+
+  it('emits a number when the input holds a numeric string', async () => {
+    const wrapper = mountNumberField();
+
+    await emitFromInput(wrapper, '42');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[42]]);
+  });
+
+  it('emits a negative number rather than clamping it, leaving rejection to the rules', async () => {
+    const wrapper = mountNumberField({ min: 0 });
+
+    await emitFromInput(wrapper, '-5');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[-5]]);
+  });
+
+  it('emits a fractional number rather than rounding it, leaving rejection to the rules', async () => {
+    const wrapper = mountNumberField();
+
+    await emitFromInput(wrapper, '3.5');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[3.5]]);
+  });
+
+  it('emits null when the input is cleared to an empty string', async () => {
+    const wrapper = mountNumberField({ modelValue: 8 });
+
+    await emitFromInput(wrapper, '');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[null]]);
+  });
+
+  it('emits null when the input reports null', async () => {
+    const wrapper = mountNumberField({ modelValue: 8 });
+
+    await emitFromInput(wrapper, null);
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[null]]);
+  });
+
+  it('emits null rather than NaN for an unparseable value', async () => {
+    const wrapper = mountNumberField();
+
+    await emitFromInput(wrapper, 'abc');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[null]]);
+  });
+
+  it('emits zero rather than null, so a legitimate 0 is not discarded', async () => {
+    const wrapper = mountNumberField();
+
+    await emitFromInput(wrapper, '0');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[0]]);
+  });
+
+  it('fails validation and shows the message when a rule rejects the value', async () => {
+    const rules: ValidationRule[] = [
+      (val: number | null) => val == null || val >= 0 || 'Must be 0 or greater',
+    ];
+    const wrapper = mountNumberField({ rules, modelValue: -5 });
+
+    const isValid = wrapper.findComponent(QInput).vm.validate();
+    await nextTick();
+
+    expect(isValid).toBe(false);
+    expect(wrapper.text()).toContain('Must be 0 or greater');
+  });
+
+  it('passes validation when the value satisfies the rules', async () => {
+    const rules: ValidationRule[] = [
+      (val: number | null) => val == null || val >= 0 || 'Must be 0 or greater',
+    ];
+    const wrapper = mountNumberField({ rules, modelValue: 4 });
+
+    const isValid = wrapper.findComponent(QInput).vm.validate();
+    await nextTick();
+
+    expect(isValid).toBe(true);
+    expect(wrapper.text()).not.toContain('Must be 0 or greater');
+  });
+});

--- a/ui/menu-website/src/components/atoms/form/number-field.vue
+++ b/ui/menu-website/src/components/atoms/form/number-field.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { ValidationRule } from 'quasar';
+
+const value = defineModel<number | null>();
+defineProps<{
+  label: string;
+  hint?: string;
+  rules?: ValidationRule[];
+  min?: number;
+  step?: number;
+}>();
+
+const onUpdate = (val: string | number | null) => {
+  if (val === null || val === '') {
+    value.value = null;
+    return;
+  }
+  const num = Number(val);
+  value.value = Number.isNaN(num) ? null : num;
+};
+</script>
+
+<template>
+  <q-input
+    :model-value="value"
+    type="number"
+    :label="label"
+    :hint="hint"
+    :rules="rules"
+    :min="min"
+    :step="step"
+    @update:model-value="onUpdate"
+  />
+</template>
+
+<style scoped></style>

--- a/ui/menu-website/src/components/atoms/form/text-field.stories.ts
+++ b/ui/menu-website/src/components/atoms/form/text-field.stories.ts
@@ -32,3 +32,52 @@ export const Hint = meta.story({
     await expect(canvas.getByText('This is a hint for the text field.')).toBeInTheDocument();
   },
 });
+
+export const Textarea = meta.story({
+  args: {
+    type: 'textarea',
+    hint: 'A short description of the recipe',
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: 'Text Field' });
+
+    await expect(input.tagName).toBe('TEXTAREA');
+
+    await userEvent.type(input, 'A rich, moist chocolate cake.');
+    await expect(args['onUpdate:modelValue']).toHaveBeenCalled();
+  },
+});
+
+const requiredRule = [(val: string | null) => !!val?.trim() || 'This field is required'];
+
+export const RuleRejectsTheValue = meta.story({
+  args: {
+    rules: requiredRule,
+    modelValue: '',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Quasar validates on blur (and on model change), so focus then leave the field.
+    await userEvent.click(canvas.getByRole('textbox', { name: 'Text Field' }));
+    await userEvent.tab();
+
+    await expect(await canvas.findByText('This field is required')).toBeInTheDocument();
+  },
+});
+
+export const RuleAcceptsTheValue = meta.story({
+  args: {
+    rules: requiredRule,
+    modelValue: 'Lasagne',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('textbox', { name: 'Text Field' }));
+    await userEvent.tab();
+
+    await expect(canvas.queryByText('This field is required')).not.toBeInTheDocument();
+  },
+});

--- a/ui/menu-website/src/components/atoms/form/text-field.test.ts
+++ b/ui/menu-website/src/components/atoms/form/text-field.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { QInput, Quasar, type ValidationRule } from 'quasar';
+import { nextTick } from 'vue';
+import TextField from './text-field.vue';
+
+const mountTextField = (props: Record<string, unknown> = {}) =>
+  mount(TextField, {
+    props: { label: 'Text Field', ...props },
+    global: { plugins: [Quasar] },
+    attachTo: document.body,
+  });
+
+describe('text-field', () => {
+  it('renders a single-line input by default', () => {
+    const wrapper = mountTextField();
+
+    expect(wrapper.find('input').exists()).toBe(true);
+    expect(wrapper.find('textarea').exists()).toBe(false);
+  });
+
+  it('renders a textarea when type is textarea', () => {
+    const wrapper = mountTextField({ type: 'textarea' });
+
+    expect(wrapper.find('textarea').exists()).toBe(true);
+    expect(wrapper.find('input').exists()).toBe(false);
+  });
+
+  it('renders the hint when one is supplied', () => {
+    const wrapper = mountTextField({ hint: 'A short description' });
+
+    expect(wrapper.text()).toContain('A short description');
+  });
+
+  it('emits update:modelValue as the user types', async () => {
+    const wrapper = mountTextField();
+
+    await wrapper.find('input').setValue('Lasagne');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['Lasagne']]);
+  });
+
+  it('accepts null as a model value', () => {
+    const wrapper = mountTextField({ modelValue: null });
+
+    expect(wrapper.find('input').element.value).toBe('');
+  });
+
+  it('fails validation and shows the message when a rule rejects the value', async () => {
+    const rules: ValidationRule[] = [(val: string | null) => !!val || 'Required'];
+    const wrapper = mountTextField({ rules, modelValue: '' });
+
+    const isValid = wrapper.findComponent(QInput).vm.validate();
+    await nextTick();
+
+    expect(isValid).toBe(false);
+    expect(wrapper.text()).toContain('Required');
+  });
+
+  it('passes validation and shows no message when the rule accepts the value', async () => {
+    const rules: ValidationRule[] = [(val: string | null) => !!val || 'Required'];
+    const wrapper = mountTextField({ rules, modelValue: 'Lasagne' });
+
+    const isValid = wrapper.findComponent(QInput).vm.validate();
+    await nextTick();
+
+    expect(isValid).toBe(true);
+    expect(wrapper.text()).not.toContain('Required');
+  });
+});

--- a/ui/menu-website/src/components/atoms/form/text-field.vue
+++ b/ui/menu-website/src/components/atoms/form/text-field.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
-const value = defineModel<string>();
-defineProps<{
-  label: string;
-  hint?: string;
-}>();
+import type { ValidationRule } from 'quasar';
+
+const value = defineModel<string | null>();
+withDefaults(
+  defineProps<{
+    label: string;
+    hint?: string;
+    rules?: ValidationRule[];
+    type?: 'text' | 'textarea';
+  }>(),
+  { type: 'text', hint: undefined, rules: undefined },
+);
 </script>
 
 <template>
-  <q-input v-model="value" :label="label" :hint="hint" />
+  <q-input v-model="value" :type="type" :label="label" :hint="hint" :rules="rules" />
 </template>
 
 <style scoped></style>

--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-name-field.stories.ts
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-name-field.stories.ts
@@ -30,3 +30,46 @@ export const PreFilledValue = meta.story({
     await expect(canvas.getByDisplayValue('Chocolate Cake')).toBeInTheDocument();
   },
 });
+
+export const EmptyNameIsRejected = meta.story({
+  args: {
+    modelValue: '',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Quasar validates on blur (and on model change), so focus then leave the field.
+    await userEvent.click(canvas.getByRole('textbox', { name: 'Name' }));
+    await userEvent.tab();
+
+    await expect(await canvas.findByText('Name is required')).toBeInTheDocument();
+  },
+});
+
+export const WhitespaceOnlyNameIsRejected = meta.story({
+  args: {
+    modelValue: '   ',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('textbox', { name: 'Name' }));
+    await userEvent.tab();
+
+    await expect(await canvas.findByText('Name is required')).toBeInTheDocument();
+  },
+});
+
+export const NonBlankNameIsAccepted = meta.story({
+  args: {
+    modelValue: 'Lasagne',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('textbox', { name: 'Name' }));
+    await userEvent.tab();
+
+    await expect(canvas.queryByText('Name is required')).not.toBeInTheDocument();
+  },
+});

--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-name-field.test.ts
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-name-field.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { QInput, Quasar } from 'quasar';
+import { nextTick } from 'vue';
+import RecipeNameField from './recipe-name-field.vue';
+
+const mountNameField = (props: Record<string, unknown> = {}) =>
+  mount(RecipeNameField, {
+    props,
+    global: { plugins: [Quasar] },
+    attachTo: document.body,
+  });
+
+const validate = async (wrapper: ReturnType<typeof mountNameField>) => {
+  const isValid = wrapper.findComponent(QInput).vm.validate();
+  await nextTick();
+  return isValid;
+};
+
+describe('recipe-name-field', () => {
+  it('renders a labelled name input with its hint', () => {
+    const wrapper = mountNameField();
+
+    expect(wrapper.find('input').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Name');
+    expect(wrapper.text()).toContain('Enter the name of the recipe');
+  });
+
+  it('displays a pre-filled model value', () => {
+    const wrapper = mountNameField({ modelValue: 'Chocolate Cake' });
+
+    expect(wrapper.find('input').element.value).toBe('Chocolate Cake');
+  });
+
+  it('emits update:modelValue as the user types', async () => {
+    const wrapper = mountNameField();
+
+    await wrapper.find('input').setValue('Lasagne');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['Lasagne']]);
+  });
+
+  it('rejects a null name', async () => {
+    const wrapper = mountNameField({ modelValue: null });
+
+    expect(await validate(wrapper)).toBe(false);
+    expect(wrapper.text()).toContain('Name is required');
+  });
+
+  it('rejects an empty name', async () => {
+    const wrapper = mountNameField({ modelValue: '' });
+
+    expect(await validate(wrapper)).toBe(false);
+    expect(wrapper.text()).toContain('Name is required');
+  });
+
+  it('rejects a whitespace-only name', async () => {
+    const wrapper = mountNameField({ modelValue: '   ' });
+
+    expect(await validate(wrapper)).toBe(false);
+    expect(wrapper.text()).toContain('Name is required');
+  });
+
+  it('accepts a non-blank name', async () => {
+    const wrapper = mountNameField({ modelValue: 'Lasagne' });
+
+    expect(await validate(wrapper)).toBe(true);
+    expect(wrapper.text()).not.toContain('Name is required');
+  });
+
+  it('accepts a name that is blank-padded but not blank', async () => {
+    const wrapper = mountNameField({ modelValue: '  Lasagne  ' });
+
+    expect(await validate(wrapper)).toBe(true);
+    expect(wrapper.text()).not.toContain('Name is required');
+  });
+});

--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-name-field.vue
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-name-field.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import TextField from '@/components/atoms/form/text-field.vue';
 
-const name = defineModel<string>();
+const name = defineModel<string | null>();
+
+const rules = [(val: string | null) => !!val?.trim() || 'Name is required'];
 </script>
 
 <template>
-  <text-field v-model="name" label="Name" hint="Enter the name of the recipe" />
+  <text-field v-model="name" label="Name" hint="Enter the name of the recipe" :rules="rules" />
 </template>
 
 <style scoped></style>

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
@@ -1,6 +1,7 @@
 import preview from '@storybook-config/preview';
 import NewRecipeForm from './new-recipe-form.vue';
-import { expect, within } from 'storybook/test';
+import { recipeCreateErrorHandler } from '@storybook-config/msw-handlers';
+import { expect, userEvent, within } from 'storybook/test';
 
 const meta = preview.meta({
   title: 'Organisms/Recipe/NewRecipeForm',
@@ -14,5 +15,103 @@ export const Default = meta.story({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByLabelText('Name')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Summary')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Yield')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Servings')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Prep time (minutes)')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Cook time (minutes)')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Total time (minutes)')).toBeInTheDocument();
+  },
+});
+
+export const EmptyTitleBlocksSubmit = meta.story({
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByText('Name is required')).toBeInTheDocument();
+  },
+});
+
+export const ValidTitlePassesValidation = meta.story({
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nameInput = canvas.getByLabelText('Name');
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.type(nameInput, 'Lasagne');
+    await userEvent.click(submitButton);
+
+    await expect(canvas.queryByText('Name is required')).not.toBeInTheDocument();
+  },
+});
+
+export const NegativeServingsBlocksSubmit = meta.story({
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nameInput = canvas.getByLabelText('Name');
+    const servingsInput = canvas.getByLabelText('Servings');
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.type(nameInput, 'Lasagne');
+    await userEvent.type(servingsInput, '-5');
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByText('Must be 0 or greater')).toBeInTheDocument();
+  },
+});
+
+export const NonIntegerServingsBlocksSubmit = meta.story({
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nameInput = canvas.getByLabelText('Name');
+    const servingsInput = canvas.getByLabelText('Servings');
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.type(nameInput, 'Lasagne');
+    await userEvent.type(servingsInput, '3.5');
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByText('Must be a whole number')).toBeInTheDocument();
+  },
+});
+
+// NOTE: MSW isn't intercepting POST requests to `/api/recipe` under
+// `vitest --project=storybook` today, for the same underlying reason
+// documented in RecipeDetail.stories.ts's Success story (a pre-existing gap
+// between `msw-storybook-addon` and this project's Storybook 10 CSF-factory
+// setup, confirmed by inspecting the raw MSW "unhandled request" warnings —
+// the request is dispatched with the exact registered method/URL but no
+// handler matches). Because `onUnhandledRequest` is configured to bypass to
+// the real network, the request always fails here regardless of which
+// handler is registered, which happens to make this specific assertion
+// (error state shown on failure) reliably true today. It will keep being
+// true once the underlying MSW gap is fixed, since the registered handler
+// below also responds with a 500. Manual verification in the real
+// interactive Storybook/dev server confirms the success path (navigating to
+// the new recipe's detail page) works correctly.
+export const SubmitFailureShowsError = meta.story({
+  parameters: {
+    msw: {
+      handlers: {
+        recipe: recipeCreateErrorHandler,
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nameInput = canvas.getByLabelText('Name');
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.type(nameInput, 'Lasagne');
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByText('Failed to save recipe. Please try again.')).toBeInTheDocument();
   },
 });

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
@@ -1,6 +1,9 @@
-import preview from '@storybook-config/preview';
+import preview, { router } from '@storybook-config/preview';
 import NewRecipeForm from './new-recipe-form.vue';
-import { recipeCreateErrorHandler } from '@storybook-config/msw-handlers';
+import {
+  recipeCreateErrorHandler,
+  recipeCreateSuccessHandler,
+} from '@storybook-config/msw-handlers';
 import { expect, userEvent, within } from 'storybook/test';
 
 const meta = preview.meta({
@@ -82,20 +85,50 @@ export const NonIntegerServingsBlocksSubmit = meta.story({
   },
 });
 
-// NOTE: MSW isn't intercepting POST requests to `/api/recipe` under
-// `vitest --project=storybook` today, for the same underlying reason
-// documented in RecipeDetail.stories.ts's Success story (a pre-existing gap
-// between `msw-storybook-addon` and this project's Storybook 10 CSF-factory
-// setup, confirmed by inspecting the raw MSW "unhandled request" warnings —
-// the request is dispatched with the exact registered method/URL but no
-// handler matches). Because `onUnhandledRequest` is configured to bypass to
-// the real network, the request always fails here regardless of which
-// handler is registered, which happens to make this specific assertion
-// (error state shown on failure) reliably true today. It will keep being
-// true once the underlying MSW gap is fixed, since the registered handler
-// below also responds with a 500. Manual verification in the real
-// interactive Storybook/dev server confirms the success path (navigating to
-// the new recipe's detail page) works correctly.
+// A fully populated form wired to a successful create. In the interactive
+// Storybook dev server (where the MSW service worker is active) submitting this
+// story navigates to the new recipe's detail page. The story therefore asserts
+// only that a fully populated form clears validation and reaches submit — see
+// the NOTE below for why the response itself is not asserted here.
+export const FullyPopulated = meta.story({
+  parameters: {
+    msw: {
+      handlers: {
+        recipe: recipeCreateSuccessHandler,
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByLabelText('Name'), 'Chocolate Cake');
+    await userEvent.type(canvas.getByLabelText('Summary'), 'A rich, moist chocolate cake.');
+    await userEvent.type(canvas.getByLabelText('Yield'), 'One 9-inch cake');
+    await userEvent.type(canvas.getByLabelText('Servings'), '8');
+    await userEvent.type(canvas.getByLabelText('Prep time (minutes)'), '20');
+    await userEvent.type(canvas.getByLabelText('Cook time (minutes)'), '35');
+    await userEvent.type(canvas.getByLabelText('Total time (minutes)'), '55');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Save recipe' }));
+
+    await expect(canvas.queryByText('Name is required')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Must be 0 or greater')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Must be a whole number')).not.toBeInTheDocument();
+  },
+});
+
+// NOTE: this story exercises the failed-submit UI, but not specifically a 500.
+// Under `vitest --project=storybook`, MSW does not serve the `*/api/recipe`
+// handler registered below — the POST fails at the network layer instead, which
+// drives the component down the same failure path. (Verified by probing: a POST
+// to a sub-path such as `*/api/recipe/probe-ok` is served correctly with its
+// body, while `*/api/recipe` is not, so this is a handler-registration gap in the
+// Storybook/Vitest MSW setup rather than anything specific to POST. It equally
+// affects the RecipeList and RecipeDetail stories.) The story keeps passing
+// unchanged once that gap is closed, since the handler below also returns 500.
+// The response-specific behaviour — the exact request payload, the 500 → banner
+// mapping, and the success path navigating to the new recipe — is covered
+// deterministically in new-recipe-form.test.ts, which mocks the API layer.
 export const SubmitFailureShowsError = meta.story({
   parameters: {
     msw: {
@@ -112,6 +145,10 @@ export const SubmitFailureShowsError = meta.story({
     await userEvent.type(nameInput, 'Lasagne');
     await userEvent.click(submitButton);
 
-    await expect(await canvas.findByText('Failed to save recipe. Please try again.')).toBeInTheDocument();
+    await expect(
+      await canvas.findByText('Failed to save recipe. Please try again.'),
+    ).toBeInTheDocument();
+    // The form stays put rather than navigating to a recipe that was never created.
+    await expect(router.currentRoute.value.path).toBe('/');
   },
 });

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
@@ -1,0 +1,308 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { Quasar } from 'quasar';
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import { defineComponent } from 'vue';
+import NewRecipeForm from './new-recipe-form.vue';
+import type { RecipeDetail } from '@/services/recipe-api';
+
+const postRecipe = vi.fn();
+
+// Mocked at the API layer rather than the service layer, so the real
+// useCreateRecipe() mutation (and therefore the real isPending/isError wiring
+// the form renders from) is exercised by these tests.
+vi.mock('@/services/recipe-api', () => ({
+  useRecipeApi: () => ({
+    postRecipe,
+    putRecipe: vi.fn(),
+    getRecipes: vi.fn(),
+    getRecipe: vi.fn(),
+    getIngredientUnits: vi.fn(),
+  }),
+}));
+
+const createdRecipe = { id: 1, title: 'Lasagne' } as unknown as RecipeDetail;
+
+const StubPage = defineComponent({ template: '<div />' });
+
+const ERROR_MESSAGE = 'Failed to save recipe. Please try again.';
+
+let router: Router;
+
+const mountForm = async () => {
+  router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: StubPage },
+      { path: '/new-recipe', component: StubPage },
+      { path: '/recipe/:recipeId', component: StubPage },
+    ],
+  });
+  await router.push('/new-recipe');
+  await router.isReady();
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return mount(NewRecipeForm, {
+    global: { plugins: [Quasar, [VueQueryPlugin, { queryClient }], router] },
+    attachTo: document.body,
+  });
+};
+
+/** Quasar renders the field label as a sibling div, not a `for`-linked <label>. */
+const field = (wrapper: VueWrapper, label: string) => {
+  const found = wrapper
+    .findAll('.q-field')
+    .find((candidate) => candidate.find('.q-field__label').text() === label);
+
+  if (!found) {
+    throw new Error(`No field labelled "${label}"`);
+  }
+
+  return found;
+};
+
+const fillField = async (wrapper: VueWrapper, label: string, value: string) => {
+  await field(wrapper, label)
+    .find<HTMLInputElement | HTMLTextAreaElement>('input, textarea')
+    .setValue(value);
+};
+
+const submit = async (wrapper: VueWrapper) => {
+  await wrapper.find('form').trigger('submit');
+  await flushPromises();
+};
+
+/**
+ * TanStack Query calls the mutation function with a second (context) argument,
+ * so assert on the recipe payload alone.
+ */
+const submittedRecipe = (call = 0) => postRecipe.mock.calls[call]?.[0] as unknown;
+
+describe('new-recipe-form', () => {
+  beforeEach(() => {
+    postRecipe.mockReset();
+    postRecipe.mockResolvedValue(createdRecipe);
+  });
+
+  it('renders every recipe metadata field and the submit button', async () => {
+    const wrapper = await mountForm();
+
+    const labels = wrapper.findAll('.q-field__label').map((label) => label.text());
+    expect(labels).toEqual([
+      'Name',
+      'Summary',
+      'Yield',
+      'Servings',
+      'Prep time (minutes)',
+      'Cook time (minutes)',
+      'Total time (minutes)',
+    ]);
+    expect(wrapper.find('button[type="submit"]').text()).toBe('Save recipe');
+  });
+
+  it('renders Summary as a multi-line field and Yield as a single-line one', async () => {
+    const wrapper = await mountForm();
+
+    expect(field(wrapper, 'Summary').find('textarea').exists()).toBe(true);
+    expect(field(wrapper, 'Yield').find('input').exists()).toBe(true);
+  });
+
+  it('renders the numeric fields as number inputs', async () => {
+    const wrapper = await mountForm();
+
+    for (const label of [
+      'Servings',
+      'Prep time (minutes)',
+      'Cook time (minutes)',
+      'Total time (minutes)',
+    ]) {
+      expect(field(wrapper, label).find('input').attributes('type')).toBe('number');
+    }
+  });
+
+  it('does not show the error banner before a submit has failed', async () => {
+    const wrapper = await mountForm();
+
+    expect(wrapper.text()).not.toContain(ERROR_MESSAGE);
+  });
+
+  it('blocks submit and reports the error when the title is empty', async () => {
+    const wrapper = await mountForm();
+
+    await submit(wrapper);
+
+    expect(postRecipe).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Name is required');
+  });
+
+  it('blocks submit when the title is whitespace only', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', '   ');
+    await submit(wrapper);
+
+    expect(postRecipe).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Name is required');
+  });
+
+  it('blocks submit when servings is negative', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await fillField(wrapper, 'Servings', '-5');
+    await submit(wrapper);
+
+    expect(postRecipe).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Must be 0 or greater');
+  });
+
+  it('blocks submit when servings is not a whole number', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await fillField(wrapper, 'Servings', '3.5');
+    await submit(wrapper);
+
+    expect(postRecipe).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Must be a whole number');
+  });
+
+  it('blocks submit when a time field is negative', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await fillField(wrapper, 'Prep time (minutes)', '-1');
+    await submit(wrapper);
+
+    expect(postRecipe).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Must be 0 or greater');
+  });
+
+  it('accepts zero for the numeric fields', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await fillField(wrapper, 'Servings', '0');
+    await submit(wrapper);
+
+    expect(submittedRecipe()).toMatchObject({ servings: 0 });
+  });
+
+  it('submits a title-only recipe with the optional fields left null', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await submit(wrapper);
+
+    expect(postRecipe).toHaveBeenCalledTimes(1);
+    expect(submittedRecipe()).toEqual({
+      title: 'Lasagne',
+      summary: null,
+      yieldText: null,
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      totalTimeMinutes: null,
+      accessScope: 'Private',
+      ingredients: [],
+      steps: [],
+    });
+  });
+
+  it('submits the populated metadata fields as numbers', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Chocolate Cake');
+    await fillField(wrapper, 'Summary', 'A rich, moist chocolate cake.');
+    await fillField(wrapper, 'Yield', 'One 9-inch cake');
+    await fillField(wrapper, 'Servings', '8');
+    await fillField(wrapper, 'Prep time (minutes)', '20');
+    await fillField(wrapper, 'Cook time (minutes)', '35');
+    await fillField(wrapper, 'Total time (minutes)', '55');
+    await submit(wrapper);
+
+    expect(submittedRecipe()).toEqual({
+      title: 'Chocolate Cake',
+      summary: 'A rich, moist chocolate cake.',
+      yieldText: 'One 9-inch cake',
+      servings: 8,
+      prepTimeMinutes: 20,
+      cookTimeMinutes: 35,
+      totalTimeMinutes: 55,
+      accessScope: 'Private',
+      ingredients: [],
+      steps: [],
+    });
+  });
+
+  it('navigates to the new recipe detail page on success', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await submit(wrapper);
+
+    expect(router.currentRoute.value.path).toBe('/recipe/1');
+    expect(wrapper.text()).not.toContain(ERROR_MESSAGE);
+  });
+
+  it('shows the error banner and stays on the form when the mutation fails', async () => {
+    postRecipe.mockRejectedValue(new Error('Failed to post recipe'));
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await submit(wrapper);
+
+    expect(wrapper.text()).toContain(ERROR_MESSAGE);
+    expect(router.currentRoute.value.path).toBe('/new-recipe');
+  });
+
+  it('does not leave the failed mutation as an unhandled rejection', async () => {
+    postRecipe.mockRejectedValue(new Error('Failed to post recipe'));
+    const unhandled = vi.fn();
+    window.addEventListener('unhandledrejection', unhandled);
+
+    const wrapper = await mountForm();
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await submit(wrapper);
+    await flushPromises();
+
+    window.removeEventListener('unhandledrejection', unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  it('clears the error banner once a retried submit succeeds', async () => {
+    postRecipe.mockRejectedValueOnce(new Error('Failed to post recipe'));
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await submit(wrapper);
+    expect(wrapper.text()).toContain(ERROR_MESSAGE);
+
+    await submit(wrapper);
+
+    expect(wrapper.text()).not.toContain(ERROR_MESSAGE);
+    expect(router.currentRoute.value.path).toBe('/recipe/1');
+  });
+
+  it('puts the submit button into its loading state while the mutation is in flight', async () => {
+    let resolvePost: (recipe: RecipeDetail) => void = () => {};
+    postRecipe.mockReturnValue(
+      new Promise<RecipeDetail>((resolve) => {
+        resolvePost = resolve;
+      }),
+    );
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await submit(wrapper);
+
+    expect(wrapper.find('button[type="submit"] .q-spinner').exists()).toBe(true);
+
+    resolvePost(createdRecipe);
+    await flushPromises();
+
+    expect(wrapper.find('button[type="submit"] .q-spinner').exists()).toBe(false);
+  });
+});

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
@@ -1,10 +1,83 @@
 <script setup lang="ts">
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
 import RecipeNameField from '@/components/molecules/recipe/fields/recipe-name-field.vue';
+import TextField from '@/components/atoms/form/text-field.vue';
+import NumberField from '@/components/atoms/form/number-field.vue';
+import { useRecipeService } from '@/services/recipe-service';
+import type { UpsertRecipe } from '@/services/recipe-api';
+
+const router = useRouter();
+const { useCreateRecipe } = useRecipeService();
+const { mutateAsync: createRecipe, isPending, isError } = useCreateRecipe();
+
+const title = ref<string | null>(null);
+const summary = ref<string | null>(null);
+const yieldText = ref<string | null>(null);
+const servings = ref<number | null>(null);
+const prepTimeMinutes = ref<number | null>(null);
+const cookTimeMinutes = ref<number | null>(null);
+const totalTimeMinutes = ref<number | null>(null);
+
+const nonNegativeIntegerRules = [
+  (val: number | null) => val == null || Number.isInteger(val) || 'Must be a whole number',
+  (val: number | null) => val == null || val >= 0 || 'Must be 0 or greater',
+];
+
+const onSubmit = async () => {
+  const recipe: UpsertRecipe = {
+    title: title.value ?? '',
+    summary: summary.value,
+    yieldText: yieldText.value,
+    servings: servings.value,
+    prepTimeMinutes: prepTimeMinutes.value,
+    cookTimeMinutes: cookTimeMinutes.value,
+    totalTimeMinutes: totalTimeMinutes.value,
+    accessScope: 'Private',
+    ingredients: [],
+    steps: [],
+  };
+
+  try {
+    const created = await createRecipe(recipe);
+    await router.push(`/recipe/${created.id}`);
+  } catch {
+    // isError from useMutation already reflects this; swallow to avoid an unhandled rejection.
+  }
+};
 </script>
 
 <template>
-  <q-form>
-    <recipe-name-field />
+  <q-form class="q-gutter-md" @submit="onSubmit">
+    <q-banner v-if="isError" class="bg-negative text-white">
+      Failed to save recipe. Please try again.
+    </q-banner>
+    <recipe-name-field v-model="title" />
+    <text-field v-model="summary" type="textarea" label="Summary" hint="A short description of the recipe" />
+    <text-field v-model="yieldText" label="Yield" hint="e.g. One 9-inch cake" />
+    <number-field v-model="servings" label="Servings" :min="0" :step="1" :rules="nonNegativeIntegerRules" />
+    <number-field
+      v-model="prepTimeMinutes"
+      label="Prep time (minutes)"
+      :min="0"
+      :step="1"
+      :rules="nonNegativeIntegerRules"
+    />
+    <number-field
+      v-model="cookTimeMinutes"
+      label="Cook time (minutes)"
+      :min="0"
+      :step="1"
+      :rules="nonNegativeIntegerRules"
+    />
+    <number-field
+      v-model="totalTimeMinutes"
+      label="Total time (minutes)"
+      :min="0"
+      :step="1"
+      :rules="nonNegativeIntegerRules"
+    />
+    <q-btn label="Save recipe" type="submit" color="primary" :loading="isPending" />
   </q-form>
 </template>
 

--- a/ui/menu-website/vitest.config.ts
+++ b/ui/menu-website/vitest.config.ts
@@ -16,6 +16,7 @@ export default mergeConfig(
         {
           extends: true,
           test: {
+            name: 'unit',
             environment: 'jsdom',
             exclude: [...configDefaults.exclude, 'e2e/**'],
             root: fileURLToPath(new URL('./', import.meta.url)),


### PR DESCRIPTION
## Summary

The recipe creation form (`new-recipe-form.vue`) previously rendered only a name field with no submit handling at all. This PR:

- Adds Summary, Yield, Servings, Prep/Cook/Total time fields to the form.
- Requires a non-blank recipe title before submit is allowed.
- Validates the numeric time/servings fields as non-negative whole numbers.
- Wires the form up to the existing `useCreateRecipe()` mutation and navigates to the new recipe's detail page (added in #1118) on success.
- Surfaces mutation failures as an inline banner instead of letting them become an unhandled promise rejection.
- Adds Storybook stories and co-located `*.test.ts` unit tests for every component this PR creates or changes (see below).

Ingredients/steps are submitted as empty arrays for now (validated as acceptable by the backend's `UpsertRecipeValidator` from #1116) — row editors for those come in #1120/#1121. `accessScope` is hardcoded to `"Private"` until the visibility selector lands in #1122.

## Test coverage

All four touched components (`number-field.vue`, `text-field.vue`, `recipe-name-field.vue`, `new-recipe-form.vue`) now have both a co-located story and a co-located unit test.

The unit tests run in a new `unit` Vitest project (jsdom + `@vue/test-utils`) — the project already existed in `vitest.config.ts` but was unnamed and had no test files, so it is now named and reachable via `pnpm test:unit`. They mock `@/services/recipe-api` rather than the service layer, so the real `useCreateRecipe()`/TanStack Query wiring behind `isPending` and `isError` is still exercised. That covers the submitted payload, the numeric validation rules, navigation to the new recipe on success, the error banner on failure, and the pending state.

The split between stories and unit tests is deliberate and documented in `AGENTS.md`: stories cover rendering, props and validation messages; unit tests cover request payloads, success/error branches and routing. This is because MSW handlers registered for `*/api/recipe` are not currently served under `vitest --project=storybook` — tracked in #1208, with the stories that assert non-behaviour as a result tracked in #1209.

That also corrects the NOTE on `SubmitFailureShowsError`. MSW *does* intercept POST requests here; a POST to a sub-path such as `*/api/recipe/probe-ok` is served correctly with its body. The real gap is narrower — handlers on the exact path `*/api/recipe` are not served, so the request fails at the network layer, and that is what drives the story down its failure path.

## Test plan

- [x] `pnpm build` (type-check + production build)
- [x] `pnpm lint`
- [x] `pnpm test` — 24 files / 101 tests passing (45 unit, 56 Storybook)
- [x] `pnpm test:storybook` — 20 files / 56 tests passing, including new stories for empty-title validation, valid-title submit, negative/non-integer servings validation, submit-failure error banner, textarea rendering and rule accept/reject on the field atoms, and a fully populated form
- [x] `pnpm test:unit` — 4 files / 45 tests passing
- [x] Manually verified in the Storybook dev server: empty-title blocks submit with a visible error, a valid title clears validation and triggers the mutation, and a failed mutation shows the error banner without crashing

Part of #1100.

Closes #1119.
