### PR TITLE
Add ingredient editor rows to recipe form

### DIFF
--- a/ui/menu-website/src/components/molecules/recipe/ingredient-row-editor.stories.ts
+++ b/ui/menu-website/src/components/molecules/recipe/ingredient-row-editor.stories.ts
@@ -1,0 +1,84 @@
+import preview from '@storybook-config/preview';
+import IngredientRowEditor from './ingredient-row-editor.vue';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+const meta = preview.meta({
+  title: 'Molecules/Recipe/IngredientRowEditor',
+  component: IngredientRowEditor,
+  tags: ['autodocs'],
+  args: {
+    canMoveUp: true,
+    canMoveDown: true,
+    'onUpdate:ingredientText': fn(),
+    'onUpdate:measureText': fn(),
+    'onUpdate:sectionTitle': fn(),
+    'onUpdate:preparationText': fn(),
+    'onUpdate:isOptional': fn(),
+    onRemove: fn(),
+    onMoveUp: fn(),
+    onMoveDown: fn(),
+  },
+});
+
+export const Default = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Measure')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Ingredient')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Preparation')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Section')).toBeInTheDocument();
+    await expect(canvas.getByText('Optional')).toBeInTheDocument();
+  },
+});
+
+export const EditingFieldsUpdatesModel = meta.story({
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByLabelText('Ingredient'), 'Flour');
+    await expect(args['onUpdate:ingredientText']).toHaveBeenCalled();
+
+    await userEvent.type(canvas.getByLabelText('Measure'), '2 cups');
+    await expect(args['onUpdate:measureText']).toHaveBeenCalled();
+
+    await userEvent.click(canvas.getByText('Optional'));
+    await expect(args['onUpdate:isOptional']).toHaveBeenCalledWith(true);
+  },
+});
+
+export const RemoveAndReorderEmitEvents = meta.story({
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Move ingredient up' }));
+    await expect(args.onMoveUp).toHaveBeenCalled();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Move ingredient down' }));
+    await expect(args.onMoveDown).toHaveBeenCalled();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Remove ingredient' }));
+    await expect(args.onRemove).toHaveBeenCalled();
+  },
+});
+
+export const FirstRowCannotMoveUp = meta.story({
+  args: {
+    canMoveUp: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Move ingredient up' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Move ingredient down' })).toBeEnabled();
+  },
+});
+
+export const LastRowCannotMoveDown = meta.story({
+  args: {
+    canMoveDown: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Move ingredient down' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Move ingredient up' })).toBeEnabled();
+  },
+});

--- a/ui/menu-website/src/components/molecules/recipe/ingredient-row-editor.vue
+++ b/ui/menu-website/src/components/molecules/recipe/ingredient-row-editor.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import TextField from '@/components/atoms/form/text-field.vue';
+
+const ingredientText = defineModel<string | null>('ingredientText');
+const measureText = defineModel<string | null>('measureText');
+const sectionTitle = defineModel<string | null>('sectionTitle');
+const preparationText = defineModel<string | null>('preparationText');
+const isOptional = defineModel<boolean>('isOptional', { default: false });
+
+defineProps<{
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+}>();
+
+defineEmits<{
+  remove: [];
+  moveUp: [];
+  moveDown: [];
+}>();
+
+const ingredientTextRules = [(val: string | null) => !!val?.trim() || 'Ingredient is required'];
+const measureTextRules = [(val: string | null) => !!val?.trim() || 'Measure is required'];
+</script>
+
+<template>
+  <div class="row q-col-gutter-sm items-start">
+    <div class="col-12 col-sm-3">
+      <text-field v-model="measureText" label="Measure" :rules="measureTextRules" />
+    </div>
+    <div class="col-12 col-sm-4">
+      <text-field v-model="ingredientText" label="Ingredient" :rules="ingredientTextRules" />
+    </div>
+    <div class="col-12 col-sm-3">
+      <text-field v-model="preparationText" label="Preparation" hint="e.g. diced, sifted" />
+    </div>
+    <div class="col-12 col-sm-2">
+      <text-field v-model="sectionTitle" label="Section" hint="e.g. For the sauce" />
+    </div>
+    <div class="col-12 row items-center q-gutter-sm">
+      <q-toggle v-model="isOptional" label="Optional" />
+      <q-btn
+        flat
+        dense
+        round
+        icon="arrow_upward"
+        :disable="!canMoveUp"
+        aria-label="Move ingredient up"
+        @click="$emit('moveUp')"
+      />
+      <q-btn
+        flat
+        dense
+        round
+        icon="arrow_downward"
+        :disable="!canMoveDown"
+        aria-label="Move ingredient down"
+        @click="$emit('moveDown')"
+      />
+      <q-btn
+        flat
+        dense
+        round
+        icon="delete"
+        color="negative"
+        aria-label="Remove ingredient"
+        @click="$emit('remove')"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
@@ -117,6 +117,71 @@ export const FullyPopulated = meta.story({
   },
 });
 
+export const AddEditRemoveIngredientRows = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const addButton = canvas.getByRole('button', { name: 'Add ingredient' });
+
+    await userEvent.click(addButton);
+    await userEvent.click(addButton);
+
+    const ingredientInputs = canvas.getAllByLabelText('Ingredient');
+    await expect(ingredientInputs).toHaveLength(2);
+
+    await userEvent.type(ingredientInputs[0], 'Flour');
+    await userEvent.type(canvas.getAllByLabelText('Measure')[0], '2 cups');
+    await userEvent.type(ingredientInputs[1], 'Sugar');
+    await userEvent.type(canvas.getAllByLabelText('Measure')[1], '1 cup');
+
+    await expect(ingredientInputs[0]).toHaveValue('Flour');
+    await expect(ingredientInputs[1]).toHaveValue('Sugar');
+
+    const removeButtons = canvas.getAllByRole('button', { name: 'Remove ingredient' });
+    await userEvent.click(removeButtons[0]);
+
+    const remainingIngredientInputs = canvas.getAllByLabelText('Ingredient');
+    await expect(remainingIngredientInputs).toHaveLength(1);
+    await expect(remainingIngredientInputs[0]).toHaveValue('Sugar');
+  },
+});
+
+export const ReorderIngredientRows = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const addButton = canvas.getByRole('button', { name: 'Add ingredient' });
+
+    await userEvent.click(addButton);
+    await userEvent.click(addButton);
+
+    const ingredientInputs = () => canvas.getAllByLabelText('Ingredient');
+    await userEvent.type(ingredientInputs()[0], 'Flour');
+    await userEvent.type(ingredientInputs()[1], 'Sugar');
+
+    const moveDownButtons = canvas.getAllByRole('button', { name: 'Move ingredient down' });
+    await userEvent.click(moveDownButtons[0]);
+
+    const reordered = ingredientInputs();
+    await expect(reordered[0]).toHaveValue('Sugar');
+    await expect(reordered[1]).toHaveValue('Flour');
+  },
+});
+
+export const EmptyIngredientRowBlocksSubmit = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nameInput = canvas.getByLabelText('Name');
+    const addButton = canvas.getByRole('button', { name: 'Add ingredient' });
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.type(nameInput, 'Lasagne');
+    await userEvent.click(addButton);
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByText('Ingredient is required')).toBeInTheDocument();
+    await expect(canvas.getByText('Measure is required')).toBeInTheDocument();
+  },
+});
+
 // NOTE: this story exercises the failed-submit UI, but not specifically a 500.
 // Under `vitest --project=storybook`, MSW does not serve the `*/api/recipe`
 // handler registered below — the POST fails at the network layer instead, which

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
@@ -25,7 +25,11 @@ const nonNegativeIntegerRules = [
   (val: number | null) => val == null || val >= 0 || 'Must be 0 or greater',
 ];
 
-const ingredients = ref<RecipeIngredientItem[]>([]);
+interface IngredientRow extends RecipeIngredientItem {
+  rowId: string;
+}
+
+const ingredients = ref<IngredientRow[]>([]);
 
 const addIngredient = () => {
   ingredients.value.push({
@@ -34,6 +38,7 @@ const addIngredient = () => {
     sectionTitle: null,
     preparationText: null,
     isOptional: false,
+    rowId: crypto.randomUUID(),
   });
 };
 
@@ -59,7 +64,14 @@ const onSubmit = async () => {
     cookTimeMinutes: cookTimeMinutes.value,
     totalTimeMinutes: totalTimeMinutes.value,
     accessScope: 'Private',
-    ingredients: ingredients.value.map((ingredient, index) => ({ ...ingredient, sortOrder: index })),
+    ingredients: ingredients.value.map((ingredient, index) => ({
+      ingredientText: ingredient.ingredientText,
+      measureText: ingredient.measureText,
+      sectionTitle: ingredient.sectionTitle,
+      preparationText: ingredient.preparationText,
+      isOptional: ingredient.isOptional,
+      sortOrder: index,
+    })),
     steps: [],
   };
 
@@ -105,7 +117,7 @@ const onSubmit = async () => {
     <div class="text-h6">Ingredients</div>
     <ingredient-row-editor
       v-for="(ingredient, index) in ingredients"
-      :key="index"
+      :key="ingredient.rowId"
       v-model:ingredient-text="ingredient.ingredientText"
       v-model:measure-text="ingredient.measureText"
       v-model:section-title="ingredient.sectionTitle"

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
@@ -4,8 +4,9 @@ import { useRouter } from 'vue-router';
 import RecipeNameField from '@/components/molecules/recipe/fields/recipe-name-field.vue';
 import TextField from '@/components/atoms/form/text-field.vue';
 import NumberField from '@/components/atoms/form/number-field.vue';
+import IngredientRowEditor from '@/components/molecules/recipe/ingredient-row-editor.vue';
 import { useRecipeService } from '@/services/recipe-service';
-import type { UpsertRecipe } from '@/services/recipe-api';
+import type { RecipeIngredientItem, UpsertRecipe } from '@/services/recipe-api';
 
 const router = useRouter();
 const { useCreateRecipe } = useRecipeService();
@@ -24,6 +25,30 @@ const nonNegativeIntegerRules = [
   (val: number | null) => val == null || val >= 0 || 'Must be 0 or greater',
 ];
 
+const ingredients = ref<RecipeIngredientItem[]>([]);
+
+const addIngredient = () => {
+  ingredients.value.push({
+    ingredientText: '',
+    measureText: '',
+    sectionTitle: null,
+    preparationText: null,
+    isOptional: false,
+  });
+};
+
+const removeIngredient = (index: number) => {
+  ingredients.value.splice(index, 1);
+};
+
+const moveIngredient = (index: number, offset: -1 | 1) => {
+  const targetIndex = index + offset;
+  if (targetIndex < 0 || targetIndex >= ingredients.value.length) return;
+  const [moved] = ingredients.value.splice(index, 1);
+  if (!moved) return;
+  ingredients.value.splice(targetIndex, 0, moved);
+};
+
 const onSubmit = async () => {
   const recipe: UpsertRecipe = {
     title: title.value ?? '',
@@ -34,7 +59,7 @@ const onSubmit = async () => {
     cookTimeMinutes: cookTimeMinutes.value,
     totalTimeMinutes: totalTimeMinutes.value,
     accessScope: 'Private',
-    ingredients: [],
+    ingredients: ingredients.value.map((ingredient, index) => ({ ...ingredient, sortOrder: index })),
     steps: [],
   };
 
@@ -48,7 +73,7 @@ const onSubmit = async () => {
 </script>
 
 <template>
-  <q-form class="q-gutter-md" @submit="onSubmit">
+  <q-form greedy class="q-gutter-md" @submit="onSubmit">
     <q-banner v-if="isError" class="bg-negative text-white">
       Failed to save recipe. Please try again.
     </q-banner>
@@ -77,6 +102,23 @@ const onSubmit = async () => {
       :step="1"
       :rules="nonNegativeIntegerRules"
     />
+    <div class="text-h6">Ingredients</div>
+    <ingredient-row-editor
+      v-for="(ingredient, index) in ingredients"
+      :key="index"
+      v-model:ingredient-text="ingredient.ingredientText"
+      v-model:measure-text="ingredient.measureText"
+      v-model:section-title="ingredient.sectionTitle"
+      v-model:preparation-text="ingredient.preparationText"
+      v-model:is-optional="ingredient.isOptional"
+      :can-move-up="index > 0"
+      :can-move-down="index < ingredients.length - 1"
+      @remove="removeIngredient(index)"
+      @move-up="moveIngredient(index, -1)"
+      @move-down="moveIngredient(index, 1)"
+    />
+    <q-btn label="Add ingredient" icon="add" flat @click="addIngredient" />
+
     <q-btn label="Save recipe" type="submit" color="primary" :loading="isPending" />
   </q-form>
 </template>


### PR DESCRIPTION
## Summary

Adds a reusable `IngredientRowEditor` molecule (measure, ingredient, preparation, section, optional toggle, plus reorder/remove controls) and wires it into `new-recipe-form.vue` as a dynamic list, replacing the hardcoded empty `ingredients: []` from #1119.

- Add/remove/reorder ingredient rows via the new component.
- `ingredientText`/`measureText` are required per row.
- `sortOrder` is recomputed from array index at submit time.
- Added `greedy` to the form's `<q-form>`: Quasar's `QForm.validate()` defaults to sequential validation that stops at the first invalid field (confirmed by reading the Quasar source), so without it, submitting a form with multiple invalid fields (e.g. an empty title *and* an empty ingredient row) would only ever show the first error, silently leaving the rest unmarked.

## Test plan

- [x] `pnpm build` (type-check + production build)
- [x] `pnpm lint`
- [x] `pnpm test:storybook` — 21 files / 52 tests passing, including new stories for the row editor (render, edit, move-up/down disabled at boundaries, remove/reorder events) and form-level add/edit/remove/reorder/required-validation coverage
- [x] Manually verified in the Storybook dev server: adding a row, leaving it empty, and submitting shows both "Ingredient is required" and "Measure is required" simultaneously (confirming the `greedy` fix)

Part of #1100.

Closes #1120.