### PR TITLE
Add step editor rows to recipe form

### DIFF
--- a/ui/menu-website/src/components/molecules/recipe/step-row-editor.stories.ts
+++ b/ui/menu-website/src/components/molecules/recipe/step-row-editor.stories.ts
@@ -1,0 +1,80 @@
+import preview from '@storybook-config/preview';
+import StepRowEditor from './step-row-editor.vue';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+const meta = preview.meta({
+  title: 'Molecules/Recipe/StepRowEditor',
+  component: StepRowEditor,
+  tags: ['autodocs'],
+  args: {
+    canMoveUp: true,
+    canMoveDown: true,
+    'onUpdate:instructionText': fn(),
+    'onUpdate:title': fn(),
+    'onUpdate:durationMinutes': fn(),
+    onRemove: fn(),
+    onMoveUp: fn(),
+    onMoveDown: fn(),
+  },
+});
+
+export const Default = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Title')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Instructions')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Duration (minutes)')).toBeInTheDocument();
+  },
+});
+
+export const EditingFieldsUpdatesModel = meta.story({
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByLabelText('Instructions'), 'Preheat the oven to 180C');
+    await expect(args['onUpdate:instructionText']).toHaveBeenCalled();
+
+    await userEvent.type(canvas.getByLabelText('Title'), 'Preheat');
+    await expect(args['onUpdate:title']).toHaveBeenCalled();
+
+    await userEvent.type(canvas.getByLabelText('Duration (minutes)'), '10');
+    await expect(args['onUpdate:durationMinutes']).toHaveBeenCalledWith(10);
+  },
+});
+
+export const RemoveAndReorderEmitEvents = meta.story({
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Move step up' }));
+    await expect(args.onMoveUp).toHaveBeenCalled();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Move step down' }));
+    await expect(args.onMoveDown).toHaveBeenCalled();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Remove step' }));
+    await expect(args.onRemove).toHaveBeenCalled();
+  },
+});
+
+export const FirstRowCannotMoveUp = meta.story({
+  args: {
+    canMoveUp: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Move step up' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Move step down' })).toBeEnabled();
+  },
+});
+
+export const LastRowCannotMoveDown = meta.story({
+  args: {
+    canMoveDown: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Move step down' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Move step up' })).toBeEnabled();
+  },
+});

--- a/ui/menu-website/src/components/molecules/recipe/step-row-editor.vue
+++ b/ui/menu-website/src/components/molecules/recipe/step-row-editor.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import TextField from '@/components/atoms/form/text-field.vue';
+import NumberField from '@/components/atoms/form/number-field.vue';
+
+const instructionText = defineModel<string | null>('instructionText');
+const title = defineModel<string | null>('title');
+const durationMinutes = defineModel<number | null>('durationMinutes');
+
+defineProps<{
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+}>();
+
+defineEmits<{
+  remove: [];
+  moveUp: [];
+  moveDown: [];
+}>();
+
+const instructionTextRules = [(val: string | null) => !!val?.trim() || 'Instructions are required'];
+const positiveIntegerRules = [
+  (val: number | null) => val == null || Number.isInteger(val) || 'Must be a whole number',
+  (val: number | null) => val == null || val > 0 || 'Must be greater than 0',
+];
+</script>
+
+<template>
+  <div class="row q-col-gutter-sm items-start">
+    <div class="col-12 col-sm-3">
+      <text-field v-model="title" label="Title" hint="e.g. Preheat the oven" />
+    </div>
+    <div class="col-12 col-sm-6">
+      <text-field
+        v-model="instructionText"
+        type="textarea"
+        label="Instructions"
+        :rules="instructionTextRules"
+      />
+    </div>
+    <div class="col-12 col-sm-3">
+      <number-field
+        v-model="durationMinutes"
+        label="Duration (minutes)"
+        :min="1"
+        :step="1"
+        :rules="positiveIntegerRules"
+      />
+    </div>
+    <div class="col-12 row items-center q-gutter-sm">
+      <q-btn
+        flat
+        dense
+        round
+        icon="arrow_upward"
+        :disable="!canMoveUp"
+        aria-label="Move step up"
+        @click="$emit('moveUp')"
+      />
+      <q-btn
+        flat
+        dense
+        round
+        icon="arrow_downward"
+        :disable="!canMoveDown"
+        aria-label="Move step down"
+        @click="$emit('moveDown')"
+      />
+      <q-btn flat dense round icon="delete" color="negative" aria-label="Remove step" @click="$emit('remove')" />
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
@@ -182,6 +182,85 @@ export const EmptyIngredientRowBlocksSubmit = meta.story({
   },
 });
 
+export const AddEditRemoveStepRows = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const addButton = canvas.getByRole('button', { name: 'Add step' });
+
+    await userEvent.click(addButton);
+    await userEvent.click(addButton);
+
+    const instructionInputs = canvas.getAllByLabelText('Instructions');
+    await expect(instructionInputs).toHaveLength(2);
+
+    await userEvent.type(instructionInputs[0], 'Preheat the oven');
+    await userEvent.type(instructionInputs[1], 'Mix the batter');
+
+    await expect(instructionInputs[0]).toHaveValue('Preheat the oven');
+    await expect(instructionInputs[1]).toHaveValue('Mix the batter');
+
+    const removeButtons = canvas.getAllByRole('button', { name: 'Remove step' });
+    await userEvent.click(removeButtons[0]);
+
+    const remainingInstructionInputs = canvas.getAllByLabelText('Instructions');
+    await expect(remainingInstructionInputs).toHaveLength(1);
+    await expect(remainingInstructionInputs[0]).toHaveValue('Mix the batter');
+  },
+});
+
+export const ReorderStepRows = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const addButton = canvas.getByRole('button', { name: 'Add step' });
+
+    await userEvent.click(addButton);
+    await userEvent.click(addButton);
+
+    const instructionInputs = () => canvas.getAllByLabelText('Instructions');
+    await userEvent.type(instructionInputs()[0], 'Preheat the oven');
+    await userEvent.type(instructionInputs()[1], 'Mix the batter');
+
+    const moveDownButtons = canvas.getAllByRole('button', { name: 'Move step down' });
+    await userEvent.click(moveDownButtons[0]);
+
+    const reordered = instructionInputs();
+    await expect(reordered[0]).toHaveValue('Mix the batter');
+    await expect(reordered[1]).toHaveValue('Preheat the oven');
+  },
+});
+
+export const EmptyStepRowBlocksSubmit = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nameInput = canvas.getByLabelText('Name');
+    const addButton = canvas.getByRole('button', { name: 'Add step' });
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.type(nameInput, 'Lasagne');
+    await userEvent.click(addButton);
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByText('Instructions are required')).toBeInTheDocument();
+  },
+});
+
+export const ZeroStepDurationBlocksSubmit = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nameInput = canvas.getByLabelText('Name');
+    const addButton = canvas.getByRole('button', { name: 'Add step' });
+    const submitButton = canvas.getByRole('button', { name: 'Save recipe' });
+
+    await userEvent.type(nameInput, 'Lasagne');
+    await userEvent.click(addButton);
+    await userEvent.type(canvas.getByLabelText('Instructions'), 'Preheat the oven');
+    await userEvent.type(canvas.getByLabelText('Duration (minutes)'), '0');
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByText('Must be greater than 0')).toBeInTheDocument();
+  },
+});
+
 // NOTE: this story exercises the failed-submit UI, but not specifically a 500.
 // Under `vitest --project=storybook`, MSW does not serve the `*/api/recipe`
 // handler registered below — the POST fails at the network layer instead, which

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
@@ -69,6 +69,33 @@ const fillField = async (wrapper: VueWrapper, label: string, value: string) => {
     .setValue(value);
 };
 
+/** Fills the Nth (0-indexed) field sharing `label`, for repeated rows like step editors. */
+const fillFieldAt = async (wrapper: VueWrapper, label: string, occurrence: number, value: string) => {
+  const matches = wrapper
+    .findAll('.q-field')
+    .filter((candidate) => candidate.find('.q-field__label').text() === label);
+
+  await matches[occurrence].find<HTMLInputElement | HTMLTextAreaElement>('input, textarea').setValue(value);
+};
+
+/**
+ * Matches icon-only buttons by their `aria-label`, and labelled buttons by their visible text
+ * (Quasar prepends the icon's ligature text, e.g. "add", so text is matched with `endsWith`).
+ */
+const clickButton = async (wrapper: VueWrapper, name: string) => {
+  const byAriaLabel = wrapper.find(`[aria-label="${name}"]`);
+  if (byAriaLabel.exists()) {
+    await byAriaLabel.trigger('click');
+    return;
+  }
+
+  const byText = wrapper.findAll('button').find((candidate) => candidate.text().endsWith(name));
+  if (!byText) {
+    throw new Error(`No button labelled "${name}"`);
+  }
+  await byText.trigger('click');
+};
+
 const submit = async (wrapper: VueWrapper) => {
   await wrapper.find('form').trigger('submit');
   await flushPromises();
@@ -209,6 +236,52 @@ describe('new-recipe-form', () => {
       ingredients: [],
       steps: [],
     });
+  });
+
+  it('submits added steps with their edited fields and a recomputed sortOrder', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await clickButton(wrapper, 'Add step');
+    await clickButton(wrapper, 'Add step');
+
+    await fillFieldAt(wrapper, 'Instructions', 0, 'Preheat the oven');
+    await fillFieldAt(wrapper, 'Title', 0, 'Preheat');
+    await fillFieldAt(wrapper, 'Duration (minutes)', 0, '10');
+    await fillFieldAt(wrapper, 'Instructions', 1, 'Mix the batter');
+
+    await submit(wrapper);
+
+    expect(submittedRecipe()).toMatchObject({
+      steps: [
+        { instructionText: 'Preheat the oven', title: 'Preheat', durationMinutes: 10, sortOrder: 0 },
+        { instructionText: 'Mix the batter', title: null, durationMinutes: null, sortOrder: 1 },
+      ],
+    });
+  });
+
+  it('recomputes step sortOrder after a reorder and does not leak the internal rowId', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await clickButton(wrapper, 'Add step');
+    await clickButton(wrapper, 'Add step');
+
+    await fillFieldAt(wrapper, 'Instructions', 0, 'Preheat the oven');
+    await fillFieldAt(wrapper, 'Instructions', 1, 'Mix the batter');
+
+    await clickButton(wrapper, 'Move step down');
+    await submit(wrapper);
+
+    expect(submittedRecipe()).toMatchObject({
+      steps: [
+        { instructionText: 'Mix the batter', sortOrder: 0 },
+        { instructionText: 'Preheat the oven', sortOrder: 1 },
+      ],
+    });
+    for (const step of (submittedRecipe() as { steps: object[] }).steps) {
+      expect(step).not.toHaveProperty('rowId');
+    }
   });
 
   it('submits the populated metadata fields as numbers', async () => {

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
@@ -5,8 +5,9 @@ import RecipeNameField from '@/components/molecules/recipe/fields/recipe-name-fi
 import TextField from '@/components/atoms/form/text-field.vue';
 import NumberField from '@/components/atoms/form/number-field.vue';
 import IngredientRowEditor from '@/components/molecules/recipe/ingredient-row-editor.vue';
+import StepRowEditor from '@/components/molecules/recipe/step-row-editor.vue';
 import { useRecipeService } from '@/services/recipe-service';
-import type { RecipeIngredientItem, UpsertRecipe } from '@/services/recipe-api';
+import type { RecipeIngredientItem, RecipeStepItem, UpsertRecipe } from '@/services/recipe-api';
 
 const router = useRouter();
 const { useCreateRecipe } = useRecipeService();
@@ -29,6 +30,14 @@ interface IngredientRow extends RecipeIngredientItem {
   rowId: string;
 }
 
+const moveItem = <T,>(array: T[], index: number, offset: -1 | 1) => {
+  const targetIndex = index + offset;
+  if (targetIndex < 0 || targetIndex >= array.length) return;
+  const [moved] = array.splice(index, 1);
+  if (!moved) return;
+  array.splice(targetIndex, 0, moved);
+};
+
 const ingredients = ref<IngredientRow[]>([]);
 
 const addIngredient = () => {
@@ -46,13 +55,23 @@ const removeIngredient = (index: number) => {
   ingredients.value.splice(index, 1);
 };
 
-const moveIngredient = (index: number, offset: -1 | 1) => {
-  const targetIndex = index + offset;
-  if (targetIndex < 0 || targetIndex >= ingredients.value.length) return;
-  const [moved] = ingredients.value.splice(index, 1);
-  if (!moved) return;
-  ingredients.value.splice(targetIndex, 0, moved);
+const moveIngredient = (index: number, offset: -1 | 1) => moveItem(ingredients.value, index, offset);
+
+const steps = ref<RecipeStepItem[]>([]);
+
+const addStep = () => {
+  steps.value.push({
+    instructionText: '',
+    title: null,
+    durationMinutes: null,
+  });
 };
+
+const removeStep = (index: number) => {
+  steps.value.splice(index, 1);
+};
+
+const moveStep = (index: number, offset: -1 | 1) => moveItem(steps.value, index, offset);
 
 const onSubmit = async () => {
   const recipe: UpsertRecipe = {
@@ -72,7 +91,7 @@ const onSubmit = async () => {
       isOptional: ingredient.isOptional,
       sortOrder: index,
     })),
-    steps: [],
+    steps: steps.value.map((step, index) => ({ ...step, sortOrder: index })),
   };
 
   try {
@@ -130,6 +149,21 @@ const onSubmit = async () => {
       @move-down="moveIngredient(index, 1)"
     />
     <q-btn label="Add ingredient" icon="add" flat @click="addIngredient" />
+
+    <div class="text-h6">Steps</div>
+    <step-row-editor
+      v-for="(step, index) in steps"
+      :key="index"
+      v-model:instruction-text="step.instructionText"
+      v-model:title="step.title"
+      v-model:duration-minutes="step.durationMinutes"
+      :can-move-up="index > 0"
+      :can-move-down="index < steps.length - 1"
+      @remove="removeStep(index)"
+      @move-up="moveStep(index, -1)"
+      @move-down="moveStep(index, 1)"
+    />
+    <q-btn label="Add step" icon="add" flat @click="addStep" />
 
     <q-btn label="Save recipe" type="submit" color="primary" :loading="isPending" />
   </q-form>

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
@@ -30,6 +30,10 @@ interface IngredientRow extends RecipeIngredientItem {
   rowId: string;
 }
 
+interface StepRow extends RecipeStepItem {
+  rowId: string;
+}
+
 const moveItem = <T,>(array: T[], index: number, offset: -1 | 1) => {
   const targetIndex = index + offset;
   if (targetIndex < 0 || targetIndex >= array.length) return;
@@ -57,13 +61,14 @@ const removeIngredient = (index: number) => {
 
 const moveIngredient = (index: number, offset: -1 | 1) => moveItem(ingredients.value, index, offset);
 
-const steps = ref<RecipeStepItem[]>([]);
+const steps = ref<StepRow[]>([]);
 
 const addStep = () => {
   steps.value.push({
     instructionText: '',
     title: null,
     durationMinutes: null,
+    rowId: crypto.randomUUID(),
   });
 };
 
@@ -91,7 +96,12 @@ const onSubmit = async () => {
       isOptional: ingredient.isOptional,
       sortOrder: index,
     })),
-    steps: steps.value.map((step, index) => ({ ...step, sortOrder: index })),
+    steps: steps.value.map((step, index) => ({
+      instructionText: step.instructionText,
+      title: step.title,
+      durationMinutes: step.durationMinutes,
+      sortOrder: index,
+    })),
   };
 
   try {
@@ -153,7 +163,7 @@ const onSubmit = async () => {
     <div class="text-h6">Steps</div>
     <step-row-editor
       v-for="(step, index) in steps"
-      :key="index"
+      :key="step.rowId"
       v-model:instruction-text="step.instructionText"
       v-model:title="step.title"
       v-model:duration-minutes="step.durationMinutes"


### PR DESCRIPTION
## Summary

Adds a reusable `StepRowEditor` molecule (title, instructions, duration) and wires it into `new-recipe-form.vue` as a dynamic list, replacing the hardcoded empty `steps: []` from #1119/#1120. Reuses the `moveItem()` reorder helper extracted for the ingredient editor.

- Add/remove/reorder step rows via the new component.
- `instructionText` is required per step.
- `durationMinutes` is validated as a positive whole number (not just non-negative) — the backend's `RecipeStepItemValidator` rejects a duration of `0`, so the frontend rule matches that constraint exactly rather than reusing the `>=0` rule from the #1119 top-level time fields, which have no backend-side validation at all.
- `sortOrder` is recomputed from array index at submit time.

## Test plan

- [x] `pnpm build` (type-check + production build)
- [x] `pnpm lint`
- [x] `pnpm test:storybook` — 22 files / 61 tests passing, including new stories for the step row editor and form-level add/edit/remove/reorder/required-validation/duration-validation coverage

Part of #1100.

Closes #1121.