### PR TITLE
Add visibility selector to recipe form

### DIFF
--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.stories.ts
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.stories.ts
@@ -7,6 +7,7 @@ const meta = preview.meta({
   component: RecipeVisibilityField,
   tags: ['autodocs'],
   args: {
+    modelValue: 'Private',
     'onUpdate:modelValue': fn(),
   },
 });
@@ -16,6 +17,7 @@ export const Default = meta.story({
     const canvas = within(canvasElement);
     const combobox = canvas.getByRole('combobox', { name: 'Visibility' });
     await expect(combobox).toHaveValue('Private');
+    await expect(canvas.getByText('Who can see this recipe')).toBeInTheDocument();
   },
 });
 
@@ -41,5 +43,17 @@ export const PreFilledValue = meta.story({
     const canvas = within(canvasElement);
     const combobox = canvas.getByRole('combobox', { name: 'Visibility' });
     await expect(combobox).toHaveValue('Visible to all Menu users');
+  },
+});
+
+/** The field shows nothing rather than a misleading "Private" when the model has no value. */
+export const NoValueSelected = meta.story({
+  args: {
+    modelValue: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByRole('combobox', { name: 'Visibility' });
+    await expect(combobox).toHaveValue('');
   },
 });

--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.stories.ts
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.stories.ts
@@ -1,0 +1,45 @@
+import preview from '@storybook-config/preview';
+import RecipeVisibilityField from './recipe-visibility-field.vue';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+const meta = preview.meta({
+  title: 'Molecules/Recipe/Fields/RecipeVisibilityField',
+  component: RecipeVisibilityField,
+  tags: ['autodocs'],
+  args: {
+    'onUpdate:modelValue': fn(),
+  },
+});
+
+export const Default = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByRole('combobox', { name: 'Visibility' });
+    await expect(combobox).toHaveValue('Private');
+  },
+});
+
+export const SelectingAuthenticatedUsersUpdatesModel = meta.story({
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByRole('combobox', { name: 'Visibility' });
+
+    await userEvent.click(combobox);
+
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole('option', { name: 'Visible to all Menu users' }));
+
+    await expect(args['onUpdate:modelValue']).toHaveBeenCalledWith('AuthenticatedUsers');
+  },
+});
+
+export const PreFilledValue = meta.story({
+  args: {
+    modelValue: 'AuthenticatedUsers',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByRole('combobox', { name: 'Visibility' });
+    await expect(combobox).toHaveValue('Visible to all Menu users');
+  },
+});

--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.test.ts
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { QSelect, Quasar } from 'quasar';
+import { nextTick } from 'vue';
+import RecipeVisibilityField from './recipe-visibility-field.vue';
+
+type VisibilityOption = { label: string; value: string };
+
+const mountVisibilityField = (props: Record<string, unknown> = {}) =>
+  mount(RecipeVisibilityField, {
+    props,
+    global: { plugins: [Quasar] },
+    attachTo: document.body,
+  });
+
+type Wrapper = ReturnType<typeof mountVisibilityField>;
+
+const optionsOf = (wrapper: Wrapper) =>
+  wrapper.findComponent(QSelect).props('options') as VisibilityOption[];
+
+/** The text the QSelect currently displays, i.e. the option label rather than the raw scope. */
+const displayedValue = (wrapper: Wrapper) => wrapper.find('.q-field__native').text();
+
+/**
+ * Emits from the inner q-select, which is what picking an item from the dropdown feeds the
+ * component at runtime. The menu itself is portalled outside the wrapper, so it is not
+ * reachable here — the dropdown-open-and-click path is covered by the Storybook story.
+ */
+const selectOption = async (wrapper: Wrapper, label: string) => {
+  const option = optionsOf(wrapper).find((candidate) => candidate.label === label);
+  if (!option) {
+    throw new Error(`No option labelled "${label}"`);
+  }
+
+  wrapper.findComponent(QSelect).vm.$emit('update:modelValue', option);
+  await nextTick();
+};
+
+describe('recipe-visibility-field', () => {
+  it('renders a labelled select with its hint', () => {
+    const wrapper = mountVisibilityField({ modelValue: 'Private' });
+
+    expect(wrapper.text()).toContain('Visibility');
+    expect(wrapper.text()).toContain('Who can see this recipe');
+  });
+
+  it('offers exactly the two visibility options', () => {
+    const wrapper = mountVisibilityField({ modelValue: 'Private' });
+
+    expect(optionsOf(wrapper)).toEqual([
+      { label: 'Private', value: 'Private' },
+      { label: 'Visible to all Menu users', value: 'AuthenticatedUsers' },
+    ]);
+  });
+
+  it('displays Private for the default new-recipe scope', () => {
+    const wrapper = mountVisibilityField({ modelValue: 'Private' });
+
+    expect(displayedValue(wrapper)).toBe('Private');
+  });
+
+  it('displays the friendly label for a pre-filled AuthenticatedUsers scope', () => {
+    const wrapper = mountVisibilityField({ modelValue: 'AuthenticatedUsers' });
+
+    expect(displayedValue(wrapper)).toBe('Visible to all Menu users');
+  });
+
+  it('emits the raw scope when Visible to all Menu users is selected', async () => {
+    const wrapper = mountVisibilityField({ modelValue: 'Private' });
+
+    await selectOption(wrapper, 'Visible to all Menu users');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['AuthenticatedUsers']]);
+  });
+
+  it('emits the raw scope when Private is selected', async () => {
+    const wrapper = mountVisibilityField({ modelValue: 'AuthenticatedUsers' });
+
+    await selectOption(wrapper, 'Private');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['Private']]);
+  });
+
+  it('displays nothing when the model has no value', () => {
+    const wrapper = mountVisibilityField();
+
+    expect(displayedValue(wrapper)).toBe('');
+  });
+
+  it('displays nothing for an unrecognised scope rather than falling back to Private', () => {
+    const wrapper = mountVisibilityField({ modelValue: 'SomeFutureScope' });
+
+    expect(displayedValue(wrapper)).toBe('');
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+});

--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.vue
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import SelectField from '@/components/atoms/form/select-field.vue';
+
+const accessScope = defineModel<string>({ default: 'Private' });
+
+const options = [
+  { label: 'Private', value: 'Private' },
+  { label: 'Visible to all Menu users', value: 'AuthenticatedUsers' },
+] as const;
+
+const selectedOption = computed({
+  get: () => options.find((option) => option.value === accessScope.value) ?? options[0],
+  set: (option) => {
+    accessScope.value = option?.value ?? options[0].value;
+  },
+});
+</script>
+
+<template>
+  <select-field v-model="selectedOption" :options="[...options]" label="Visibility" />
+</template>
+
+<style scoped></style>

--- a/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.vue
+++ b/ui/menu-website/src/components/molecules/recipe/fields/recipe-visibility-field.vue
@@ -1,24 +1,35 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import SelectField from '@/components/atoms/form/select-field.vue';
+import type { RecipeAccessScope } from '@/services/recipe-api';
 
-const accessScope = defineModel<string>({ default: 'Private' });
+// The default lives with the owning form, not here, so the field can never display a
+// value the parent has not actually been given.
+const accessScope = defineModel<RecipeAccessScope>();
 
-const options = [
+type VisibilityOption = { label: string; value: RecipeAccessScope };
+
+const options: VisibilityOption[] = [
   { label: 'Private', value: 'Private' },
   { label: 'Visible to all Menu users', value: 'AuthenticatedUsers' },
-] as const;
+];
 
-const selectedOption = computed({
-  get: () => options.find((option) => option.value === accessScope.value) ?? options[0],
+const selectedOption = computed<VisibilityOption | undefined>({
+  // An unrecognised scope renders as empty rather than silently reading as Private.
+  get: () => options.find((option) => option.value === accessScope.value),
   set: (option) => {
-    accessScope.value = option?.value ?? options[0].value;
+    accessScope.value = option?.value;
   },
 });
 </script>
 
 <template>
-  <select-field v-model="selectedOption" :options="[...options]" label="Visibility" />
+  <select-field
+    v-model="selectedOption"
+    :options="options"
+    label="Visibility"
+    hint="Who can see this recipe"
+  />
 </template>
 
 <style scoped></style>

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.stories.ts
@@ -24,6 +24,20 @@ export const Default = meta.story({
     await expect(canvas.getByLabelText('Prep time (minutes)')).toBeInTheDocument();
     await expect(canvas.getByLabelText('Cook time (minutes)')).toBeInTheDocument();
     await expect(canvas.getByLabelText('Total time (minutes)')).toBeInTheDocument();
+    await expect(canvas.getByRole('combobox', { name: 'Visibility' })).toHaveValue('Private');
+  },
+});
+
+export const SelectingVisibilityUpdatesForm = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByRole('combobox', { name: 'Visibility' });
+
+    await userEvent.click(combobox);
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole('option', { name: 'Visible to all Menu users' }));
+
+    await expect(combobox).toHaveValue('Visible to all Menu users');
   },
 });
 

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
-import { Quasar } from 'quasar';
+import { QSelect, Quasar } from 'quasar';
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 import { createMemoryHistory, createRouter, type Router } from 'vue-router';
-import { defineComponent } from 'vue';
+import { defineComponent, nextTick } from 'vue';
 import NewRecipeForm from './new-recipe-form.vue';
 import type { RecipeDetail } from '@/services/recipe-api';
 
@@ -67,6 +67,23 @@ const fillField = async (wrapper: VueWrapper, label: string, value: string) => {
   await field(wrapper, label)
     .find<HTMLInputElement | HTMLTextAreaElement>('input, textarea')
     .setValue(value);
+};
+
+/**
+ * Picks a dropdown option by label. The QSelect menu is portalled outside the wrapper, so the
+ * selection is emitted from the QSelect itself; the click-through path is covered by the story.
+ */
+const selectOption = async (wrapper: VueWrapper, fieldLabel: string, optionLabel: string) => {
+  const select = field(wrapper, fieldLabel).findComponent(QSelect);
+  const options = select.props('options') as { label: string; value: string }[];
+  const option = options.find((candidate) => candidate.label === optionLabel);
+
+  if (!option) {
+    throw new Error(`No option labelled "${optionLabel}" in field "${fieldLabel}"`);
+  }
+
+  select.vm.$emit('update:modelValue', option);
+  await nextTick();
 };
 
 /** Fills the Nth (0-indexed) field sharing `label`, for repeated rows like step editors. */
@@ -237,6 +254,27 @@ describe('new-recipe-form', () => {
       ingredients: [],
       steps: [],
     });
+  });
+
+  it('defaults the submitted visibility to Private', async () => {
+    const wrapper = await mountForm();
+
+    expect(field(wrapper, 'Visibility').find('.q-field__native').text()).toBe('Private');
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await submit(wrapper);
+
+    expect(submittedRecipe()).toMatchObject({ accessScope: 'Private' });
+  });
+
+  it('submits the selected visibility scope', async () => {
+    const wrapper = await mountForm();
+
+    await fillField(wrapper, 'Name', 'Lasagne');
+    await selectOption(wrapper, 'Visibility', 'Visible to all Menu users');
+    await submit(wrapper);
+
+    expect(submittedRecipe()).toMatchObject({ accessScope: 'AuthenticatedUsers' });
   });
 
   it('submits added steps with their edited fields and a recomputed sortOrder', async () => {

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.test.ts
@@ -119,6 +119,7 @@ describe('new-recipe-form', () => {
     const labels = wrapper.findAll('.q-field__label').map((label) => label.text());
     expect(labels).toEqual([
       'Name',
+      'Visibility',
       'Summary',
       'Yield',
       'Servings',

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
@@ -8,14 +8,19 @@ import IngredientRowEditor from '@/components/molecules/recipe/ingredient-row-ed
 import StepRowEditor from '@/components/molecules/recipe/step-row-editor.vue';
 import RecipeVisibilityField from '@/components/molecules/recipe/fields/recipe-visibility-field.vue';
 import { useRecipeService } from '@/services/recipe-service';
-import type { RecipeIngredientItem, RecipeStepItem, UpsertRecipe } from '@/services/recipe-api';
+import type {
+  RecipeAccessScope,
+  RecipeIngredientItem,
+  RecipeStepItem,
+  UpsertRecipe,
+} from '@/services/recipe-api';
 
 const router = useRouter();
 const { useCreateRecipe } = useRecipeService();
 const { mutateAsync: createRecipe, isPending, isError } = useCreateRecipe();
 
 const title = ref<string | null>(null);
-const accessScope = ref('Private');
+const accessScope = ref<RecipeAccessScope>('Private');
 const summary = ref<string | null>(null);
 const yieldText = ref<string | null>(null);
 const servings = ref<number | null>(null);

--- a/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
+++ b/ui/menu-website/src/components/organisms/recipe/new-recipe-form.vue
@@ -6,6 +6,7 @@ import TextField from '@/components/atoms/form/text-field.vue';
 import NumberField from '@/components/atoms/form/number-field.vue';
 import IngredientRowEditor from '@/components/molecules/recipe/ingredient-row-editor.vue';
 import StepRowEditor from '@/components/molecules/recipe/step-row-editor.vue';
+import RecipeVisibilityField from '@/components/molecules/recipe/fields/recipe-visibility-field.vue';
 import { useRecipeService } from '@/services/recipe-service';
 import type { RecipeIngredientItem, RecipeStepItem, UpsertRecipe } from '@/services/recipe-api';
 
@@ -14,6 +15,7 @@ const { useCreateRecipe } = useRecipeService();
 const { mutateAsync: createRecipe, isPending, isError } = useCreateRecipe();
 
 const title = ref<string | null>(null);
+const accessScope = ref('Private');
 const summary = ref<string | null>(null);
 const yieldText = ref<string | null>(null);
 const servings = ref<number | null>(null);
@@ -87,7 +89,7 @@ const onSubmit = async () => {
     prepTimeMinutes: prepTimeMinutes.value,
     cookTimeMinutes: cookTimeMinutes.value,
     totalTimeMinutes: totalTimeMinutes.value,
-    accessScope: 'Private',
+    accessScope: accessScope.value,
     ingredients: ingredients.value.map((ingredient, index) => ({
       ingredientText: ingredient.ingredientText,
       measureText: ingredient.measureText,
@@ -119,6 +121,7 @@ const onSubmit = async () => {
       Failed to save recipe. Please try again.
     </q-banner>
     <recipe-name-field v-model="title" />
+    <recipe-visibility-field v-model="accessScope" />
     <text-field v-model="summary" type="textarea" label="Summary" hint="A short description of the recipe" />
     <text-field v-model="yieldText" label="Yield" hint="e.g. One 9-inch cake" />
     <number-field v-model="servings" label="Servings" :min="0" :step="1" :rules="nonNegativeIntegerRules" />

--- a/ui/menu-website/src/services/recipe-api.ts
+++ b/ui/menu-website/src/services/recipe-api.ts
@@ -11,6 +11,13 @@ export type RecipeStepItem = components['schemas']['RecipeStepItem'];
 export type IngredientUnit = components['schemas']['IngredientUnit'];
 export type RecipeListScope = 'mine' | 'authenticated';
 
+/**
+ * The values the API accepts for `accessScope`. The generated type is a bare `string`
+ * (the backend validates against `RecipeAccessScope.AllValues`), so narrow it here to
+ * catch typos at compile time.
+ */
+export type RecipeAccessScope = 'Private' | 'AuthenticatedUsers';
+
 export const useRecipeApi = () => {
   const auth = useAuth();
 


### PR DESCRIPTION
## Summary

Adds a `RecipeVisibilityField` molecule wrapping the existing `select-field.vue` atom, translating between `UpsertRecipe.accessScope`'s raw string values (`Private` / `AuthenticatedUsers`) and the underlying `QSelect`'s `{label, value}` option shape.

- Dropdown with two options: "Private" and "Visible to all Menu users".
- Defaults to `Private` for new recipes.
- Wired into `new-recipe-form.vue`, replacing the hardcoded `'Private'` literal in the submit payload — the selected value now flows through to `UpsertRecipe.accessScope`.

This is the last PR in the #1099/#1100 stacked sequence.

## Test plan

- [x] `pnpm build` (type-check + production build)
- [x] `pnpm lint`
- [x] `pnpm test:storybook` — 23 files / 65 tests passing, including a real dropdown-open-and-select interaction test (verified genuine, not a false positive, by temporarily sabotaging the assertion and confirming it fails correctly)
- [x] Manually verified in the Storybook dev server that the field renders with the correct default and label

Part of #1100.

Closes #1122.