### PR TITLE
Add skill for diagnosing frontend TypeScript build dependency failures

### DIFF
--- a/.claude/skills/frontend-typescript-build-deps/SKILL.md
+++ b/.claude/skills/frontend-typescript-build-deps/SKILL.md
@@ -1,77 +1,43 @@
 ---
 name: frontend-typescript-build-deps
-description: Diagnose "Cannot find module '@/generated/open-api/menu-api'" and similar frontend TypeScript build/lint failures in a fresh checkout or worktree — the frontend build depends on generated artifacts that are not checked into git and must be regenerated in the right order.
+description: Use when `pnpm build`, `vue-tsc`, or `pnpm lint` in ui/menu-website fails with "Cannot find module '@/generated/open-api/menu-api'" in a fresh checkout or new worktree — a red herring that looks like a code regression but is actually missing generated build artifacts.
 ---
 
 # Frontend TypeScript Build Dependencies
 
-## Purpose
+`Cannot find module '@/generated/open-api/menu-api'` is a **red herring**: it reads like a broken import or bad merge, but in a fresh checkout or worktree it almost always means two gitignored build artifacts were never generated.
 
-In a fresh checkout or new git worktree, `pnpm build`, `vue-tsc`, or `pnpm lint` in `ui/menu-website` can fail with:
+## The dependency chain
 
-```
-Cannot find module '@/generated/open-api/menu-api' or its corresponding type declarations.
-```
+| Artifact | Produced by |
+|---|---|
+| `open-api/menu-api.json` (repo root) | `dotnet build` on `MenuApi` (the `GenerateOpenApiDocuments` MSBuild target) |
+| `ui/menu-website/src/generated/open-api/menu-api.ts` | `pnpm generate-openapi`, which reads `open-api/menu-api.json` |
 
-This **looks like a real regression** (missing export, broken import, bad merge) but usually isn't. It means the generated OpenAPI artifacts simply don't exist yet in this checkout. Use this skill to recognize and resolve that quickly instead of debugging the wrong thing.
+Both are gitignored. `src/services/recipe-api.ts` and other service-layer files import from `@/generated/open-api/menu-api`; if it was never generated in this checkout, that import fails as a TypeScript module-resolution error rather than an obvious "file missing" message.
 
-## Why this happens
+Worktrees share git history but not gitignored build outputs, so this hits every new worktree under `worktrees/` on first use.
 
-Two artifacts that the frontend TypeScript build depends on are **not checked into git**, and only exist after running specific commands:
+## Steps
 
-| Artifact | Produced by | Notes |
-|---|---|---|
-| `open-api/menu-api.json` (repo root) | `dotnet build` on `MenuApi` (the `GenerateOpenApiDocuments` MSBuild target) | Gitignored (`open-api/.gitignore` ignores `*.json`) |
-| `ui/menu-website/src/generated/open-api/menu-api.ts` | `pnpm generate-openapi` (from `ui/menu-website/`), which reads `open-api/menu-api.json` | Gitignored; entire `src/generated/` folder is regenerated, never hand-edited |
+1. **Confirm it's the red herring.** Check whether `ui/menu-website/src/generated/open-api/menu-api.ts` exists. If it exists and the error still occurs, stop — this is a genuine regression (e.g. a renamed or removed backend endpoint the frontend wasn't updated for), not a missing-artifact issue. Completion: you know which case you're in.
+2. **Build the backend first.**
+   ```bash
+   cd backend
+   dotnet restore MenuApi.sln
+   dotnet build MenuApi.sln --configuration Release --no-restore
+   ```
+   Completion: `open-api/menu-api.json` exists at the repo root.
+3. **Regenerate the frontend types.**
+   ```bash
+   cd ui/menu-website
+   pnpm generate-openapi
+   ```
+   Completion: `src/generated/open-api/menu-api.ts` exists and is non-empty.
+4. **Re-run the command that failed** (`pnpm build`, `pnpm lint`, or `vue-tsc`). Completion: the module-resolution error is gone.
 
-`src/services/recipe-api.ts` and other service-layer files import types from `@/generated/open-api/menu-api`. If that file was never generated in this checkout/worktree, the import fails — which surfaces as a TypeScript module-resolution error in `vue-tsc`, `pnpm build`, or `pnpm lint`, not as an obviously-missing-file error.
-
-This bites most often in:
-- A fresh `git clone`.
-- A new git worktree created under `worktrees/` (per repo convention) — worktrees share history but not gitignored build outputs.
-- CI-like scenarios where only `ui/menu-website` was checked out or `pnpm install` was run without a prior backend build.
-
-## Fix: two-step regeneration, in order
-
-The backend must be built **before** the frontend generation step — the frontend step reads the JSON the backend produces.
-
-### 1. Build the backend first
-
-```bash
-cd backend
-dotnet restore MenuApi.sln
-dotnet build MenuApi.sln --configuration Release --no-restore
-```
-
-This writes `open-api/menu-api.json` at the repo root.
-
-### 2. Then regenerate the frontend types
-
-```bash
-cd ui/menu-website
-pnpm generate-openapi
-```
-
-This reads `../../open-api/menu-api.json` and writes `src/generated/open-api/menu-api.ts`.
-
-### 3. Re-run the frontend build/lint
-
-```bash
-cd ui/menu-website
-pnpm build
-pnpm lint
-```
-
-The module-resolution error should be gone.
-
-## Diagnosis checklist
-
-Before assuming a real code regression when frontend TypeScript checks fail:
-
-1. Does `ui/menu-website/src/generated/open-api/menu-api.ts` exist at all? If not, this is the missing-artifact issue, not a code bug.
-2. Does `open-api/menu-api.json` exist at the repo root? If not, the backend hasn't been built yet in this checkout/worktree — start at step 1 above.
-3. Only after both artifacts exist and the error persists should you treat it as a genuine regression (e.g. an endpoint was renamed/removed and frontend code wasn't updated to match).
+The order matters: step 3 reads the file step 2 produces. Running `pnpm generate-openapi` first regenerates against a stale or missing spec.
 
 ## Related
 
-See the [openapi-sync](../openapi-sync/SKILL.md) skill for the full regeneration workflow to use **after intentionally changing a backend endpoint** (this skill is about recognizing and resolving the fresh-checkout/worktree case specifically).
+[openapi-sync](../openapi-sync/SKILL.md) — the same regeneration mechanics, for use after *intentionally* changing a backend endpoint rather than diagnosing a fresh checkout or worktree.

--- a/.claude/skills/frontend-typescript-build-deps/SKILL.md
+++ b/.claude/skills/frontend-typescript-build-deps/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: frontend-typescript-build-deps
+description: Diagnose "Cannot find module '@/generated/open-api/menu-api'" and similar frontend TypeScript build/lint failures in a fresh checkout or worktree — the frontend build depends on generated artifacts that are not checked into git and must be regenerated in the right order.
+---
+
+# Frontend TypeScript Build Dependencies
+
+## Purpose
+
+In a fresh checkout or new git worktree, `pnpm build`, `vue-tsc`, or `pnpm lint` in `ui/menu-website` can fail with:
+
+```
+Cannot find module '@/generated/open-api/menu-api' or its corresponding type declarations.
+```
+
+This **looks like a real regression** (missing export, broken import, bad merge) but usually isn't. It means the generated OpenAPI artifacts simply don't exist yet in this checkout. Use this skill to recognize and resolve that quickly instead of debugging the wrong thing.
+
+## Why this happens
+
+Two artifacts that the frontend TypeScript build depends on are **not checked into git**, and only exist after running specific commands:
+
+| Artifact | Produced by | Notes |
+|---|---|---|
+| `open-api/menu-api.json` (repo root) | `dotnet build` on `MenuApi` (the `GenerateOpenApiDocuments` MSBuild target) | Gitignored (`open-api/.gitignore` ignores `*.json`) |
+| `ui/menu-website/src/generated/open-api/menu-api.ts` | `pnpm generate-openapi` (from `ui/menu-website/`), which reads `open-api/menu-api.json` | Gitignored; entire `src/generated/` folder is regenerated, never hand-edited |
+
+`src/services/recipe-api.ts` and other service-layer files import types from `@/generated/open-api/menu-api`. If that file was never generated in this checkout/worktree, the import fails — which surfaces as a TypeScript module-resolution error in `vue-tsc`, `pnpm build`, or `pnpm lint`, not as an obviously-missing-file error.
+
+This bites most often in:
+- A fresh `git clone`.
+- A new git worktree created under `worktrees/` (per repo convention) — worktrees share history but not gitignored build outputs.
+- CI-like scenarios where only `ui/menu-website` was checked out or `pnpm install` was run without a prior backend build.
+
+## Fix: two-step regeneration, in order
+
+The backend must be built **before** the frontend generation step — the frontend step reads the JSON the backend produces.
+
+### 1. Build the backend first
+
+```bash
+cd backend
+dotnet restore MenuApi.sln
+dotnet build MenuApi.sln --configuration Release --no-restore
+```
+
+This writes `open-api/menu-api.json` at the repo root.
+
+### 2. Then regenerate the frontend types
+
+```bash
+cd ui/menu-website
+pnpm generate-openapi
+```
+
+This reads `../../open-api/menu-api.json` and writes `src/generated/open-api/menu-api.ts`.
+
+### 3. Re-run the frontend build/lint
+
+```bash
+cd ui/menu-website
+pnpm build
+pnpm lint
+```
+
+The module-resolution error should be gone.
+
+## Diagnosis checklist
+
+Before assuming a real code regression when frontend TypeScript checks fail:
+
+1. Does `ui/menu-website/src/generated/open-api/menu-api.ts` exist at all? If not, this is the missing-artifact issue, not a code bug.
+2. Does `open-api/menu-api.json` exist at the repo root? If not, the backend hasn't been built yet in this checkout/worktree — start at step 1 above.
+3. Only after both artifacts exist and the error persists should you treat it as a genuine regression (e.g. an endpoint was renamed/removed and frontend code wasn't updated to match).
+
+## Related
+
+See the [openapi-sync](../openapi-sync/SKILL.md) skill for the full regeneration workflow to use **after intentionally changing a backend endpoint** (this skill is about recognizing and resolving the fresh-checkout/worktree case specifically).


### PR DESCRIPTION
## Summary
- Adds a new agent skill, `frontend-typescript-build-deps`, documenting that `pnpm build`/`vue-tsc`/`pnpm lint` in `ui/menu-website` depend on two generated artifacts not checked into git: `open-api/menu-api.json` (from `dotnet build MenuApi`) and `ui/menu-website/src/generated/open-api/menu-api.ts` (from `pnpm generate-openapi`)
- Without both in place, a fresh checkout or new git worktree fails with `Cannot find module '@/generated/open-api/menu-api'`, which looks like a real regression but isn't
- Spells out the required order (backend build first, then `pnpm generate-openapi`) and a quick diagnosis checklist, and cross-links the existing `openapi-sync` skill for the intentional-endpoint-change workflow

## Test plan
- [x] N/A — documentation-only change (new SKILL.md), no code touched