### PR TITLE
Upgrade all .NET packages to latest versions

### DIFF
--- a/backend/Menu.AppHost/Menu.AppHost.csproj
+++ b/backend/Menu.AppHost/Menu.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,12 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.JavaScript.Extensions" Version="13.3.0" />
-    <!-- Pin transitive MessagePack (via Aspire.Hosting -> StreamJsonRpc) past known vulnerabilities in 2.5.192 -->
-    <PackageReference Include="MessagePack" Version="2.5.302" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.JavaScript.Extensions" Version="13.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/Menu.MigrationService/Menu.MigrationService.csproj
+++ b/backend/Menu.MigrationService/Menu.MigrationService.csproj
@@ -9,7 +9,7 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/Menu.ServiceDefaults/Menu.ServiceDefaults.csproj
+++ b/backend/Menu.ServiceDefaults/Menu.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
 
 </Project>

--- a/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
+++ b/backend/MenuApi.Integration.Tests/MenuApi.Integration.Tests.csproj
@@ -22,9 +22,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting.Testing" Version="13.3.5" />
+		<PackageReference Include="Aspire.Hosting.Testing" Version="13.4.6" />
 		<PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />		
-		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />		
+		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />		
 		<PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -33,9 +33,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
 		<PackageReference Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
-		<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
+		<PackageReference Include="Microsoft.Testing.Platform" Version="2.3.3" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 	</ItemGroup>
 

--- a/backend/MenuApi.Tests/MenuApi.Tests.csproj
+++ b/backend/MenuApi.Tests/MenuApi.Tests.csproj
@@ -26,7 +26,7 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
-		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
 		<PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -36,9 +36,9 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FakeItEasy" Version="9.0.1" />
-		<PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Testing.Platform" Version="2.3.3" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 	</ItemGroup>
 

--- a/backend/MenuApi/MenuApi.csproj
+++ b/backend/MenuApi/MenuApi.csproj
@@ -30,22 +30,22 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.5" />
+		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.8">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.10">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
 		<PackageReference Include="Riok.Mapperly" Version="4.3.1" />
-		<PackageReference Include="Vogen" Version="8.0.5" />
+		<PackageReference Include="Vogen" Version="8.0.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/backend/MenuDB.Tests/MenuDB.Tests.csproj
+++ b/backend/MenuDB.Tests/MenuDB.Tests.csproj
@@ -16,15 +16,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Testing.Platform" Version="2.3.3" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
-		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
 		<PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
 		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/MenuDB/MenuDB.csproj
+++ b/backend/MenuDB/MenuDB.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## What changed

Every NuGet package in the backend solution is now on its latest release — `dotnet list package --outdated` returns nothing across all nine projects.

**Aspire family** — updated with `aspire update` (CLI 13.4.6), which handles the AppHost SDK alongside the hosting/component packages:

| Package | From | To |
|---|---|---|
| `Aspire.AppHost.Sdk` | 13.3.5 | 13.4.6 |
| `Aspire.Hosting.JavaScript` / `.Redis` / `.SqlServer` | 13.3.5 | 13.4.6 |
| `Aspire.Microsoft.EntityFrameworkCore.SqlServer` (MenuApi + MigrationService) | 13.3.5 | 13.4.6 |

Two Aspire-adjacent packages the CLI does not reach, bumped with `dotnet add package`:

| Package | From | To |
|---|---|---|
| `Aspire.Hosting.Testing` | 13.3.5 | 13.4.6 |
| `CommunityToolkit.Aspire.Hosting.JavaScript.Extensions` | 13.3.0 | 13.4.0 |

**Everything else**

| Package | From | To |
|---|---|---|
| EF Core (`SqlServer`, `Design`, `InMemory`), `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.Extensions.ApiDescription.Server` | 10.0.8 | 10.0.10 |
| `Microsoft.Extensions.Http.Resilience` / `.ServiceDiscovery` | 10.6.0 | 10.8.0 |
| All five OpenTelemetry packages | 1.15.x | 1.17.0 |
| `Vogen` | 8.0.5 | 8.0.7 |
| `AwesomeAssertions` | 9.4.0 | 9.5.0 |
| `Microsoft.Testing.Platform` | 2.2.3 | 2.3.3 |
| `GitHubActionsTestLogger` | 3.0.4 | 3.0.5 |

## Reviewer notes

**The `MessagePack` pin in `Menu.AppHost.csproj` is removed.** It existed to force the transitive MessagePack reference past the vulnerabilities in 2.5.192. Aspire 13.4.6 brings `StreamJsonRpc` 2.25.29, which resolves MessagePack 2.5.302 on its own, so the pin had become a no-op. `dotnet list package --vulnerable --include-transitive` is clean without it. MessagePack 3.1.8 was deliberately *not* taken — that is a major-version bump away from what StreamJsonRpc expects.

`aspire update` also generated a `backend/nuget.config` as a side effect. It only re-declared nuget.org (already the default) but added a `<clear />` that would have dropped the local Microsoft SDKs package source, so it was deleted rather than committed. Restore works fine without it.

## Verification

- Release build clean: 0 warnings, 0 errors (`TreatWarningsAsErrors` is on)
- `MenuApi.Tests` — 109/109 passed
- `MenuDB.Tests` — 11/11 passed
- `MenuApi.Integration.Tests` — 42/42 passed against the real SQL Server container
- The regenerated `open-api/menu-api.json` is byte-identical, so no frontend type regeneration is needed

No source code changed — this is package versions only.
