### PR TITLE
Add Dependabot config for .NET, pnpm, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    groups:
+      dotnet-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/ui/menu-website"
+    schedule:
+      interval: "weekly"
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` covering three ecosystems, each with weekly grouped updates:
  - `nuget` on `/backend` (.NET packages via `MenuApi.sln`)
  - `npm` on `/ui/menu-website` (pnpm auto-detected via `pnpm-lock.yaml`)
  - `github-actions` on `/` (workflow action versions)

## Test plan
- [ ] Confirm Dependabot config validates in the repo's Insights > Dependency graph > Dependabot tab after merge