### PR TITLE
Add pnpm-upgrade skill

### DIFF
--- a/.claude/skills/pnpm-upgrade/MAJOR-SWEEP.md
+++ b/.claude/skills/pnpm-upgrade/MAJOR-SWEEP.md
@@ -1,0 +1,61 @@
+# Sweeps spanning several majors
+
+## Stack the units
+
+Ship one PR per unit from step 2, ordered safest first: the bulk within-major bump at the bottom, then one major (or peer-locked set of majors) per layer above it. A major needing source changes carries those changes in its own PR, which keeps each layer independently reviewable and revertible.
+
+Build the stack with [gh-stack](../gh-stack/SKILL.md). Insert at the bottom — where a Node floor or other precondition belongs — by unstacking, re-initialising with the new order, then cascade-rebasing.
+
+Run the full step 4 verification on **every** branch, not only the top. Layers rebase onto each other, so a broken lower layer breaks everything above it.
+
+CI runs the frontend job on stacked PRs whose base is another branch, so each layer gets its own real signal.
+
+## Lockfile conflicts
+
+Every layer touches `pnpm-lock.yaml`, so expect a conflict per rebase step. Resolve it by regenerating rather than reading it: take the incoming branch's copy and let pnpm reconcile it against the already-resolved `package.json`.
+
+```bash
+git checkout --theirs ui/menu-website/pnpm-lock.yaml
+(cd ui/menu-website && pnpm install)
+git add ui/menu-website/pnpm-lock.yaml
+```
+
+`package.json` conflicts need hands: keep the layer's own bumps *and* whatever an earlier layer introduced on adjacent lines. A bulk bump changing the devDependencies block will collide with a single-line change like `@types/node` sitting inside it.
+
+## Confirm the restructure moved history, not results
+
+A clean rebase reports nothing about correctness. Two checks settle it — the second is the **invariant**: reordering PRs may move a change between commits, and must leave the end state untouched.
+
+```bash
+# the change survived every layer, not just the top
+for b in <branches>; do echo -n "$b "; git show "$b:ui/menu-website/package.json" | grep '"@types/node"'; done
+
+# the end state is unchanged by the restructure
+git diff <old-top-sha> <new-top-branch>
+```
+
+An empty second diff means only history moved. Anything else means the rebase changed the result.
+
+Read the per-layer output as a progression: each layer should show its own bump arriving and every earlier layer's still in place.
+
+## Node targeting
+
+`engines.node` and `@types/node` both answer which Node line the project targets, so move them together, at the bottom of the stack — the floor is declared before anything depends on it.
+
+Derive `engines.node` from what the packages declare rather than guessing. Run this from `ui/menu-website` with the final versions installed:
+
+```bash
+node -e "
+const fs=require('fs'),path=require('path');
+const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));
+for(const n of [...Object.keys(pkg.dependencies||{}),...Object.keys(pkg.devDependencies||{})].sort()){
+  try{const j=JSON.parse(fs.readFileSync(path.join('node_modules',...n.split('/'),'package.json'),'utf8'));
+  if(j.engines&&j.engines.node)console.log(n.padEnd(32),j.engines.node);}catch(e){}
+}"
+```
+
+Take the intersection. Watch for packages restricting themselves to even-numbered LTS majors — `@quasar/app-vite@3` declares `^30 || ^28 || ^26 || ^24 || ^22.22.0`, which excludes odd majors like 25 and 27 from a strict reading.
+
+`@types/node` tracks Node release lines 1:1, so its major matches a line `engines.node` actually supports. Moving it from 25.x to 24.x reads as a downgrade and is the correct direction when 24 is the LTS line being targeted, because 25.x types the non-LTS Current line. Say so in the commit message, or it gets reverted as a mistake.
+
+CI pins `node-version: 22.x` in `.github/workflows/main.yml`. Read the resolved version out of a job log before assuming a raised floor is safe. pnpm leaves `engine-strict` unset, so a mismatch warns rather than fails.

--- a/.claude/skills/pnpm-upgrade/SKILL.md
+++ b/.claude/skills/pnpm-upgrade/SKILL.md
@@ -1,124 +1,70 @@
 ---
 name: pnpm-upgrade
-description: Use when upgrading the pnpm dependencies in ui/menu-website — surveying what is outdated, splitting major bumps into a reviewable stack of PRs, and the verification order and dependency traps that decide whether the lint/test results can be trusted.
+description: Upgrade pnpm dependencies in ui/menu-website. Use when the user wants to update frontend packages or act on `pnpm outdated`, or when a dependency bump has broken lint, types, or tests.
 ---
 
 # Upgrading pnpm packages
 
-Use this skill for any dependency bump in `ui/menu-website`, from a single package to a full sweep. The mechanics (`pnpm up`) are trivial; everything below is about the parts that silently produce wrong answers.
+The work is making the verification mean something: in this repo both the type-checker and the Storybook suite will report success while measuring nothing.
 
-## Generate the OpenAPI types before you lint or build
+## 1. Make the toolchain sighted
 
-**Do this first, every time, in every worktree.** `src/generated/open-api/menu-api.ts` is gitignored, so a fresh worktree does not have it.
+`src/generated/open-api/menu-api.ts` is gitignored, so a fresh checkout or worktree lacks it. Without it, `data` from `openapi-fetch` resolves to an error type and lint and type-check run **blind** — they pass while answering a different question than CI does. Rules like `@typescript-eslint/no-unnecessary-type-assertion` stay quiet locally and fire in CI, which lands the fix in whichever branch you were on when you finally saw it.
 
 ```bash
 cd backend && dotnet restore MenuApi.sln && dotnet build MenuApi.sln --configuration Release --no-restore
 cd ui/menu-website && pnpm generate-openapi
 ```
 
-Without it, `data` from `openapi-fetch` resolves to an error type. Lint and type-check still *run* — they just answer a different question than CI does. In practice this means rules like `@typescript-eslint/no-unnecessary-type-assertion` stay quiet locally and fire in CI, so a lint error gets "fixed" in whichever PR you happened to be on when you finally saw it, rather than the one that introduced it.
+Completion: `src/generated/open-api/menu-api.ts` exists and is non-empty. Full diagnosis in [frontend-typescript-build-deps](../frontend-typescript-build-deps/SKILL.md).
 
-If a lint or build result surprises you, confirm this file exists before believing the result. See [frontend-typescript-build-deps](../frontend-typescript-build-deps/SKILL.md).
-
-## Survey and group
+## 2. Survey and group
 
 ```bash
 cd ui/menu-website && pnpm outdated
 ```
 
-Split the work into one PR per reviewable unit, ordered safest first:
+Assign every outdated package to a unit: one bulk unit for everything staying within its major, then one per major bump — or one per set of majors that peer-depend on each other, like `quasar` + `@quasar/app-vite` + `@quasar/vite-plugin`.
 
-1. **One bulk PR** for everything staying within its current major.
-2. **One PR per major bump**, or per group of majors that must move together because they peer-depend on each other (e.g. `quasar` + `@quasar/app-vite` + `@quasar/vite-plugin` all require each other's new majors).
+For each major, check what consumes it before committing to the bump. A compiler is gated by its type-checker: `typescript` cannot reach 7 while `vue-tsc`, which wraps the TS compiler API and runs `type-check`, has no release supporting it.
 
-A major that needs source changes belongs in its own PR with those changes, not folded into the bulk one. Ship the stack with [gh-stack](../gh-stack/SKILL.md); each layer stays independently reviewable and revertible.
+Completion: every package from `pnpm outdated` sits in a named unit, and each major has had its consumers checked.
 
-Before bumping a major, check what consumes it — a compiler is gated by its type-checker, not just itself. `typescript` cannot move to 7 while `vue-tsc` (which wraps the TS compiler API and runs this repo's `type-check`) has no release supporting it.
+## 3. Bump and install
 
-## Verify every branch
-
-Run the full set on each branch, not just the top of the stack. Later layers rebase onto earlier ones, so a broken lower layer breaks everything above it.
+Edit the ranges in `package.json`, then:
 
 ```bash
 pnpm install
+```
+
+Completion: install exits clean, and `pnpm why <pkg>` reports a single version of any framework package the bump touched.
+
+When a bump breaks something you did not touch, read [TRAPS.md](TRAPS.md) before debugging — pnpm's resolution produces several failures that look like application bugs.
+
+## 4. Verify, and make the green load-bearing
+
+```bash
 pnpm run lint
-pnpm run build          # runs type-check + vite build
+pnpm run build          # type-check + vite build
 pnpm run test:unit
 pnpm run test:storybook
 ```
 
-`pnpm run test:e2e` is a stale scaffold asserting `You did it!` and fails on `main`; it is not a signal. For UI-affecting bumps (Quasar, Storybook, MSW) also smoke-check the dev server in a browser and confirm the console is clean.
+Skip `pnpm run test:e2e`: it asserts a scaffold string (`You did it!`) and fails on `main`, so it carries no signal either way.
 
-## Dependency traps seen in this repo
+An assertion is **load-bearing** when it can only pass if the thing under test actually works. Storybook stories asserting `No recipes found.` passed identically whether MSW served an empty list or served nothing at all, because the component renders the same fallback either way — so the suite stayed green through a completely dead mock.
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| A direct dep breaks after bumping something unrelated | pnpm resolves the newest version satisfying every range in the graph, so a transitive peer can float a package past what a direct consumer supports. Bumping `vitest` pulled `msw` to 2.15 via `@vitest/mocker`, breaking `msw-storybook-addon@2`'s use of `worker.context`. | Pin it in `overrides` in `pnpm-workspace.yaml`, with a comment saying when the pin can go |
-| Type errors on a plugin you did not touch | A package declaring a framework as a regular (non-peer) dependency gets its own copy. `@auth0/auth0-vue` does this with `vue`, producing two structurally incompatible `App`/`Plugin` types and breaking `app.use(createAuth0())` | `overrides` entry forcing a single version; confirm with `pnpm why vue` reporting one version |
-| `ERR_PNPM_UNUSED_PATCH` | The patched package upgraded and the patch no longer applies | Check whether the bug is fixed upstream. If so, delete the patch and its `patchedDependencies` entry rather than re-rolling it |
-| Lint fails on code you did not change | eslint/plugin bumps make existing suppressions and assertions redundant (unused `eslint-disable`, unnecessary type assertions) | Remove them in the PR that bumps the linter, since that PR is what made them stale |
-| `mockServiceWorker.js` shows as modified with an empty diff | msw's postinstall rewrites it with different line endings | `git restore` it. After a real msw bump, regenerate deliberately: `pnpm exec msw init public --save` |
+For any bump touching mocking, rendering, or the test environment, add an assertion that reaches for mocked data (`await canvas.findByText('Chocolate Cake')`) and watch it fail before the fix and pass after. Runtime is a second tell: a story that "passes" in 2.4s and drops to 190ms once the mock works was previously passing on a timeout.
 
-Use `pnpm why <pkg>` to see what is pulling a version and whether more than one copy is installed.
+Completion: every suite green, and for bumps in those areas, at least one load-bearing assertion observed failing first.
 
-## Tests that pass for the wrong reason
+## 5. Commit
 
-A green suite is not evidence a mock is working. Storybook stories asserting `No recipes found.` passed both when MSW served an empty list *and* when MSW served nothing at all, because the component renders the same fallback either way.
+Record why a version was chosen whenever the choice reads as a mistake — a pin, an override, an apparent downgrade — so the next person keeps it instead of reverting it.
 
-When a bump touches mocking, probe before trusting it: add an assertion that can only pass if the mock is actually serving data (`await canvas.findByText('Chocolate Cake')`), and watch it fail before your fix and pass after. Runtimes are a hint too — a story that "passes" in 2.4s and drops to 190ms once the mock works was previously passing on a timeout.
+Completion: the commit ends with the `Co-authored-by:` trailer from [agent-identity](../agent-identity/SKILL.md), and each pin or override states its rationale.
 
-## Node targeting in package.json
+## Sweeps that span several majors
 
-Two fields describe which Node the project targets; move them together.
-
-`engines.node` should be the intersection of what the upgraded packages declare. Derive it rather than guessing — run this from `ui/menu-website` with the final versions installed:
-
-```bash
-node -e "
-const fs=require('fs'),path=require('path');
-const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));
-for(const n of [...Object.keys(pkg.dependencies||{}),...Object.keys(pkg.devDependencies||{})].sort()){
-  try{const j=JSON.parse(fs.readFileSync(path.join('node_modules',...n.split('/'),'package.json'),'utf8'));
-  if(j.engines&&j.engines.node)console.log(n.padEnd(32),j.engines.node);}catch(e){}
-}"
-```
-
-Watch for packages restricting themselves to even-numbered (LTS) majors — `@quasar/app-vite@3` does, which excludes odd majors like 25 and 27 from a strict intersection.
-
-`@types/node` tracks Node release lines 1:1, so its major should match a line `engines.node` actually supports. Moving it from 25.x to 24.x reads as a downgrade but is the correct direction when 24 is the LTS line being targeted — 25.x types the non-LTS "Current" line.
-
-CI pins `node-version: 22.x` in `.github/workflows/main.yml`; check the resolved version in a job log before assuming a raised floor is safe. pnpm does not enforce `engines` (`engine-strict` is unset), so a mismatch warns rather than fails.
-
-## Rebasing the stack
-
-Every branch touches `pnpm-lock.yaml`, so expect a conflict per layer. Do not hand-merge the lockfile — take the incoming branch's copy and let pnpm reconcile it against the resolved `package.json`:
-
-```bash
-git checkout --theirs ui/menu-website/pnpm-lock.yaml
-(cd ui/menu-website && pnpm install)
-git add ui/menu-website/pnpm-lock.yaml
-```
-
-Resolve `package.json` by hand: keep the layer's own bumps *and* whatever earlier layers introduced on adjacent lines.
-
-A clean rebase is not proof of a correct one. Afterwards verify both:
-
-```bash
-# the change survived on every branch, not just the top
-for b in <branches>; do echo -n "$b "; git show "$b:ui/menu-website/package.json" | grep '"@types/node"'; done
-
-# the final state is unchanged by the restructure
-git diff <old-top-sha> <new-top-branch>
-```
-
-An empty second diff means only history moved. A non-empty one means the rebase changed the result.
-
-## Committing
-
-Follow [agent-identity](../agent-identity/SKILL.md) — every commit ends with a `Co-authored-by:` trailer. State *why* a version was chosen when it is not obvious (a pin, an override, an apparent downgrade), since the next person will otherwise read it as a mistake and revert it.
-
-## Related
-
-- [frontend-typescript-build-deps](../frontend-typescript-build-deps/SKILL.md) — the missing-generated-types red herring
-- [openapi-sync](../openapi-sync/SKILL.md) — regenerating API types after a backend change
-- [gh-stack](../gh-stack/SKILL.md) — creating and rebasing stacked PRs
+When the upgrade is large enough to ship as more than one PR, read [MAJOR-SWEEP.md](MAJOR-SWEEP.md): stacking the units into reviewable PRs, resolving the lockfile conflict that appears on every rebase, and moving `engines.node` and `@types/node` together.

--- a/.claude/skills/pnpm-upgrade/SKILL.md
+++ b/.claude/skills/pnpm-upgrade/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: pnpm-upgrade
+description: Use when upgrading the pnpm dependencies in ui/menu-website — surveying what is outdated, splitting major bumps into a reviewable stack of PRs, and the verification order and dependency traps that decide whether the lint/test results can be trusted.
+---
+
+# Upgrading pnpm packages
+
+Use this skill for any dependency bump in `ui/menu-website`, from a single package to a full sweep. The mechanics (`pnpm up`) are trivial; everything below is about the parts that silently produce wrong answers.
+
+## Generate the OpenAPI types before you lint or build
+
+**Do this first, every time, in every worktree.** `src/generated/open-api/menu-api.ts` is gitignored, so a fresh worktree does not have it.
+
+```bash
+cd backend && dotnet restore MenuApi.sln && dotnet build MenuApi.sln --configuration Release --no-restore
+cd ui/menu-website && pnpm generate-openapi
+```
+
+Without it, `data` from `openapi-fetch` resolves to an error type. Lint and type-check still *run* — they just answer a different question than CI does. In practice this means rules like `@typescript-eslint/no-unnecessary-type-assertion` stay quiet locally and fire in CI, so a lint error gets "fixed" in whichever PR you happened to be on when you finally saw it, rather than the one that introduced it.
+
+If a lint or build result surprises you, confirm this file exists before believing the result. See [frontend-typescript-build-deps](../frontend-typescript-build-deps/SKILL.md).
+
+## Survey and group
+
+```bash
+cd ui/menu-website && pnpm outdated
+```
+
+Split the work into one PR per reviewable unit, ordered safest first:
+
+1. **One bulk PR** for everything staying within its current major.
+2. **One PR per major bump**, or per group of majors that must move together because they peer-depend on each other (e.g. `quasar` + `@quasar/app-vite` + `@quasar/vite-plugin` all require each other's new majors).
+
+A major that needs source changes belongs in its own PR with those changes, not folded into the bulk one. Ship the stack with [gh-stack](../gh-stack/SKILL.md); each layer stays independently reviewable and revertible.
+
+Before bumping a major, check what consumes it — a compiler is gated by its type-checker, not just itself. `typescript` cannot move to 7 while `vue-tsc` (which wraps the TS compiler API and runs this repo's `type-check`) has no release supporting it.
+
+## Verify every branch
+
+Run the full set on each branch, not just the top of the stack. Later layers rebase onto earlier ones, so a broken lower layer breaks everything above it.
+
+```bash
+pnpm install
+pnpm run lint
+pnpm run build          # runs type-check + vite build
+pnpm run test:unit
+pnpm run test:storybook
+```
+
+`pnpm run test:e2e` is a stale scaffold asserting `You did it!` and fails on `main`; it is not a signal. For UI-affecting bumps (Quasar, Storybook, MSW) also smoke-check the dev server in a browser and confirm the console is clean.
+
+## Dependency traps seen in this repo
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| A direct dep breaks after bumping something unrelated | pnpm resolves the newest version satisfying every range in the graph, so a transitive peer can float a package past what a direct consumer supports. Bumping `vitest` pulled `msw` to 2.15 via `@vitest/mocker`, breaking `msw-storybook-addon@2`'s use of `worker.context`. | Pin it in `overrides` in `pnpm-workspace.yaml`, with a comment saying when the pin can go |
+| Type errors on a plugin you did not touch | A package declaring a framework as a regular (non-peer) dependency gets its own copy. `@auth0/auth0-vue` does this with `vue`, producing two structurally incompatible `App`/`Plugin` types and breaking `app.use(createAuth0())` | `overrides` entry forcing a single version; confirm with `pnpm why vue` reporting one version |
+| `ERR_PNPM_UNUSED_PATCH` | The patched package upgraded and the patch no longer applies | Check whether the bug is fixed upstream. If so, delete the patch and its `patchedDependencies` entry rather than re-rolling it |
+| Lint fails on code you did not change | eslint/plugin bumps make existing suppressions and assertions redundant (unused `eslint-disable`, unnecessary type assertions) | Remove them in the PR that bumps the linter, since that PR is what made them stale |
+| `mockServiceWorker.js` shows as modified with an empty diff | msw's postinstall rewrites it with different line endings | `git restore` it. After a real msw bump, regenerate deliberately: `pnpm exec msw init public --save` |
+
+Use `pnpm why <pkg>` to see what is pulling a version and whether more than one copy is installed.
+
+## Tests that pass for the wrong reason
+
+A green suite is not evidence a mock is working. Storybook stories asserting `No recipes found.` passed both when MSW served an empty list *and* when MSW served nothing at all, because the component renders the same fallback either way.
+
+When a bump touches mocking, probe before trusting it: add an assertion that can only pass if the mock is actually serving data (`await canvas.findByText('Chocolate Cake')`), and watch it fail before your fix and pass after. Runtimes are a hint too — a story that "passes" in 2.4s and drops to 190ms once the mock works was previously passing on a timeout.
+
+## Node targeting in package.json
+
+Two fields describe which Node the project targets; move them together.
+
+`engines.node` should be the intersection of what the upgraded packages declare. Derive it rather than guessing — run this from `ui/menu-website` with the final versions installed:
+
+```bash
+node -e "
+const fs=require('fs'),path=require('path');
+const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));
+for(const n of [...Object.keys(pkg.dependencies||{}),...Object.keys(pkg.devDependencies||{})].sort()){
+  try{const j=JSON.parse(fs.readFileSync(path.join('node_modules',...n.split('/'),'package.json'),'utf8'));
+  if(j.engines&&j.engines.node)console.log(n.padEnd(32),j.engines.node);}catch(e){}
+}"
+```
+
+Watch for packages restricting themselves to even-numbered (LTS) majors — `@quasar/app-vite@3` does, which excludes odd majors like 25 and 27 from a strict intersection.
+
+`@types/node` tracks Node release lines 1:1, so its major should match a line `engines.node` actually supports. Moving it from 25.x to 24.x reads as a downgrade but is the correct direction when 24 is the LTS line being targeted — 25.x types the non-LTS "Current" line.
+
+CI pins `node-version: 22.x` in `.github/workflows/main.yml`; check the resolved version in a job log before assuming a raised floor is safe. pnpm does not enforce `engines` (`engine-strict` is unset), so a mismatch warns rather than fails.
+
+## Rebasing the stack
+
+Every branch touches `pnpm-lock.yaml`, so expect a conflict per layer. Do not hand-merge the lockfile — take the incoming branch's copy and let pnpm reconcile it against the resolved `package.json`:
+
+```bash
+git checkout --theirs ui/menu-website/pnpm-lock.yaml
+(cd ui/menu-website && pnpm install)
+git add ui/menu-website/pnpm-lock.yaml
+```
+
+Resolve `package.json` by hand: keep the layer's own bumps *and* whatever earlier layers introduced on adjacent lines.
+
+A clean rebase is not proof of a correct one. Afterwards verify both:
+
+```bash
+# the change survived on every branch, not just the top
+for b in <branches>; do echo -n "$b "; git show "$b:ui/menu-website/package.json" | grep '"@types/node"'; done
+
+# the final state is unchanged by the restructure
+git diff <old-top-sha> <new-top-branch>
+```
+
+An empty second diff means only history moved. A non-empty one means the rebase changed the result.
+
+## Committing
+
+Follow [agent-identity](../agent-identity/SKILL.md) — every commit ends with a `Co-authored-by:` trailer. State *why* a version was chosen when it is not obvious (a pin, an override, an apparent downgrade), since the next person will otherwise read it as a mistake and revert it.
+
+## Related
+
+- [frontend-typescript-build-deps](../frontend-typescript-build-deps/SKILL.md) — the missing-generated-types red herring
+- [openapi-sync](../openapi-sync/SKILL.md) — regenerating API types after a backend change
+- [gh-stack](../gh-stack/SKILL.md) — creating and rebasing stacked PRs

--- a/.claude/skills/pnpm-upgrade/TRAPS.md
+++ b/.claude/skills/pnpm-upgrade/TRAPS.md
@@ -1,0 +1,35 @@
+# Resolution traps
+
+pnpm resolves the newest version satisfying every range in the graph. That single rule produces most of the failures below, and they surface far from the package you bumped, which is what makes them read as application bugs.
+
+Start with `pnpm why <pkg>`: it names what pulls a version in, and reveals when more than one copy is installed.
+
+## A direct dependency breaks after bumping something unrelated
+
+A transitive peer can **float** a package past what a direct consumer supports. Bumping `vitest` pulled `msw` to 2.15 through `@vitest/mocker`, and `msw-storybook-addon@2` relies on `worker.context`, which 2.15 removed — so every Storybook test died on `Cannot set properties of undefined (setting 'activationPromise')`.
+
+Pin the floated package in `overrides` in `pnpm-workspace.yaml`, with a comment naming the condition that retires the pin. Here that condition was the addon reaching v3, at which point the pin came out and both moved together.
+
+## Type errors on a plugin you did not touch
+
+A package that declares a framework as a regular dependency rather than a peer gets its own copy of it. `@auth0/auth0-vue` does this with `vue`, so bumping `vue` left two copies installed, producing two structurally incompatible `App`/`Plugin` types and breaking `app.use(createAuth0())` under `vue-tsc` with `provides no match for the signature`.
+
+Force a single version through `overrides`. Confirm with `pnpm why vue` reporting `Found 1 version`.
+
+## ERR_PNPM_UNUSED_PATCH
+
+The patched package moved and the patch no longer applies. Check whether the bug was fixed upstream before re-rolling it — `@storybook/addon-vitest`'s Windows absolute-path bug was fixed a different way in 10.5.7, so the patch and its `patchedDependencies` entry were deleted rather than rebuilt.
+
+## Lint fails on code you did not change
+
+Linter and plugin bumps make existing suppressions redundant: unused `eslint-disable` directives, and assertions that `@typescript-eslint/no-unnecessary-type-assertion` now recognises as no-ops. Clear them in the PR that bumps the linter, since that bump is what made them stale.
+
+Verify this one with the generated OpenAPI types present, or the result is **blind** — see step 1 of [SKILL.md](SKILL.md).
+
+## mockServiceWorker.js shows as modified with an empty diff
+
+msw's postinstall rewrites the file with different line endings. `git restore` it. After a deliberate msw bump, regenerate it properly:
+
+```bash
+pnpm exec msw init public --save
+```


### PR DESCRIPTION
Captures the process and failure modes from the `ui/menu-website` dependency sweep (the stack starting at #1237), so the next upgrade doesn't rediscover them.

Independent of that stack — this only adds `.claude/skills/pnpm-upgrade/` and can merge in any order.

## Shape

Written against the `writing-great-skills` guidance, so the structure is doing work:

- **`SKILL.md`** (70 lines) — five ordered steps, each closing on a checkable completion criterion.
- **`TRAPS.md`** (35 lines) — pnpm resolution failures, reached by a pointer worded as the situation that triggers it: *"when a bump breaks something you did not touch"*.
- **`MAJOR-SWEEP.md`** (61 lines) — stacking, lockfile conflicts, and Node targeting, reached only when the sweep spans several majors.

Split by branch: a routine patch bump reads only `SKILL.md` and never loads the other two.

## What it actually teaches

Weighted toward the things that **quietly produce wrong answers** rather than failing loudly, since those cost the time:

- **`blind` tooling.** The generated OpenAPI types are gitignored, so a fresh worktree lacks them and `data` from `openapi-fetch` becomes an error type. Lint and type-check still pass — they answer a different question than CI. That's how a `no-unnecessary-type-assertion` error got fixed in the wrong PR during this sweep.
- **`load-bearing` assertions.** Storybook stories asserting `No recipes found.` passed identically whether MSW served an empty list or nothing at all, because the component renders the same fallback either way — the suite stayed green through a completely dead mock. Includes how to probe for it, and the runtime tell (a 2.4s "pass" dropping to 190ms once the mock works).
- **Two ways pnpm breaks something you didn't touch** — a transitive peer floating a package past a direct consumer (`vitest` → `@vitest/mocker` → `msw` 2.15, breaking `msw-storybook-addon@2`), and a non-peer framework dependency getting its own copy (`@auth0/auth0-vue` and `vue`, producing incompatible `App`/`Plugin` types).
- **A clean rebase reports nothing about correctness.** Spells out the two checks: did the change survive every layer, and is the end state invariant.

## Verification

- All six cross-links resolve (four sibling skills, two internal)
- Every `pnpm run` script referenced exists in `package.json`
- The embedded `engines.node` survey script was run as written
- 5 steps, 5 completion criteria; no steering-by-prohibition
- Picked up by skill discovery (no index to update — skills are auto-discovered)

🤖 Generated with Claude Code