### PR TITLE
Drop corepack and the pnpm packageManager pin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,8 +212,8 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Enable pnpm with corepack
-        run: corepack enable pnpm
+      - name: Install latest pnpm
+        run: npm install -g pnpm@latest
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ pnpm storybook            # Storybook dev server (port 6006)
 
 Always run `pnpm test:storybook` after making any change under `ui/menu-website/src/` — it catches regressions in components exercised by existing stories, not just changes to story files themselves.
 
-pnpm's version is pinned via corepack (`packageManager` in `package.json`), which is also what Aspire's `WithPnpm()` shells out to when the AppHost starts the full stack (via `aspire start`, the agent-preferred path, or `dotnet run --project Menu.AppHost`). `pnpm-workspace.yaml` sets `confirmModulesPurge: false` so a pinned-version bump self-heals a stale `node_modules` automatically; if you ever see `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` anyway, just run `pnpm install` once by hand from `ui/menu-website/`.
+pnpm's version is not pinned — whatever `pnpm` is on your `PATH` is what runs, including when Aspire's `WithPnpm()` shells out to it to start the full stack (via `aspire start`, the agent-preferred path, or `dotnet run --project Menu.AppHost`). `package.json` declares a `>= 10` floor under `engines`, and CI installs the latest pnpm; do not reintroduce a `packageManager` pin or corepack. `pnpm-workspace.yaml` sets `confirmModulesPurge: false` so upgrading your global pnpm across a major self-heals a stale `node_modules` automatically; if you ever see `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` anyway, just run `pnpm install` once by hand from `ui/menu-website/`.
 
 ### Component Test Coverage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ pnpm storybook            # Storybook dev server (port 6006)
 
 Always run `pnpm test:storybook` after making any change under `ui/menu-website/src/` — it catches regressions in components exercised by existing stories, not just changes to story files themselves.
 
-pnpm's version is not pinned — whatever `pnpm` is on your `PATH` is what runs, including when Aspire's `WithPnpm()` shells out to it to start the full stack (via `aspire start`, the agent-preferred path, or `dotnet run --project Menu.AppHost`). `package.json` declares a `>= 10` floor under `engines`, and CI installs the latest pnpm; do not reintroduce a `packageManager` pin or corepack. `pnpm-workspace.yaml` sets `confirmModulesPurge: false` so upgrading your global pnpm across a major self-heals a stale `node_modules` automatically; if you ever see `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` anyway, just run `pnpm install` once by hand from `ui/menu-website/`.
+pnpm's version is not pinned — whatever `pnpm` is on your `PATH` is what runs, including when Aspire's `WithPnpm()` shells out to it to start the full stack (via `aspire start`, the agent-preferred path, or `dotnet run --project Menu.AppHost`). `package.json` declares a `>= 10` floor under `engines`, and CI installs the latest pnpm; do not reintroduce a `packageManager` pin or corepack. `pnpm-workspace.yaml` sets `confirmModulesPurge: false` so upgrading your global pnpm across a major version self-heals a stale `node_modules` directory automatically; if you ever see `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` anyway, just run `pnpm install` once by hand from `ui/menu-website/`.
 
 ### Component Test Coverage
 

--- a/ui/menu-website/package.json
+++ b/ui/menu-website/package.json
@@ -82,9 +82,9 @@
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
     "npm": ">= 6.13.4",
+    "pnpm": ">= 10",
     "yarn": ">= 1.21.1"
   },
-  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "msw": {
     "workerDirectory": [
       "public"

--- a/ui/menu-website/pnpm-workspace.yaml
+++ b/ui/menu-website/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 # Aspire's WithPnpm() spawns pnpm non-interactively with no TTY. Without this,
-# a pnpm major-version bump (see the corepack packageManager pin in package.json)
-# leaves a stale node_modules store from the old version, and pnpm aborts waiting
-# for a purge confirmation prompt it can never receive
-# (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
+# any pnpm major-version change between the pnpm on your PATH and the store on
+# disk (e.g. after upgrading your global pnpm) leaves a stale node_modules from
+# the old version, and pnpm aborts waiting for a purge confirmation prompt it
+# can never receive (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
 confirmModulesPurge: false
 allowBuilds:
   '@parcel/watcher': true

--- a/ui/menu-website/pnpm-workspace.yaml
+++ b/ui/menu-website/pnpm-workspace.yaml
@@ -1,8 +1,9 @@
 # Aspire's WithPnpm() spawns pnpm non-interactively with no TTY. Without this,
-# any pnpm major-version change between the pnpm on your PATH and the store on
-# disk (e.g. after upgrading your global pnpm) leaves a stale node_modules from
-# the old version, and pnpm aborts waiting for a purge confirmation prompt it
-# can never receive (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
+# a pnpm major-version mismatch — the pnpm on your PATH differing from the one
+# that wrote node_modules, e.g. after upgrading your global pnpm — leaves behind
+# a node_modules directory pnpm considers stale. pnpm then aborts waiting for a
+# purge confirmation prompt it can never receive
+# (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
 confirmModulesPurge: false
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
Closes #1256.

Stops using corepack to manage pnpm. Locally pnpm now resolves to whatever is on your `PATH`; CI installs the latest pnpm rather than resurrecting a pinned version.

## Changes

- **`ui/menu-website/package.json`** — removed the `packageManager` pin (`pnpm@11.21.0+sha512…`) and added a `"pnpm": ">= 10"` floor under `engines`. A floor, not a pin: a genuinely ancient pnpm still fails fast.
- **`.github/workflows/main.yml`** — `corepack enable pnpm` → `npm install -g pnpm@latest`, in the same position so `pnpm` is on `PATH` before the `pnpm store path --silent` cache step that follows.
- **`ui/menu-website/pnpm-workspace.yaml`** — `confirmModulesPurge: false` stays; the comment no longer blames a corepack pin bump. The trigger is now any pnpm major-version change between the pnpm on your `PATH` and the store on disk.
- **`AGENTS.md`** — the pnpm paragraph in the frontend section now describes the unpinned setup and says explicitly not to reintroduce the pin or corepack.

`codeql.yml` needs no change — it has no pnpm setup.

## Why `npm install -g pnpm@latest` rather than `pnpm/action-setup@v4`

Both keep the store cache step working. `pnpm/action-setup` would add a new GitHub Action for the `github-actions` Dependabot ecosystem to bump every week — exactly the "a bump nobody actually wants to review" churn this change is removing. The plain `npm install -g` has no such tail.

## Trade-off being accepted knowingly

The `packageManager` pin was the only thing guaranteeing everyone writes the same `pnpm-lock.yaml` format. With CI on `latest` and developers on whatever they have installed, a future pnpm major that bumps `lockfileVersion` will surface as a large unrelated lockfile diff, and `--frozen-lockfile` in CI will fail if a developer's older pnpm wrote an older format. That is a conscious merge-time decision, not an oversight.

Today there is no drift: pnpm 10 and 11 both write `lockfileVersion: '9.0'`, and the floor is set to `>= 10` because that is what is actually installed locally (a `>= 11` floor would have rejected it).

## Verification

Run in a clean worktree so nothing was inherited from the pinned install, with pnpm 10.31.0 off `PATH` and no `packageManager` field present:

- `pnpm install --frozen-lockfile` — clean, **no lockfile drift**
- `pnpm run generate-openapi` — ok
- `pnpm lint` — 0 errors (9 pre-existing `vue/one-component-per-file` warnings on `*.test.ts`)
- `pnpm build` — ok
- `pnpm test` — **38 files, 242 tests, all passing**

`aspire start` was **not** re-run: a live `aspire run` stack was already up on this machine and tearing it down was not worth the disruption. `WithPnpm()` only requires a `pnpm` on `PATH` (`Menu.AppHost/Program.cs:27-28` references no version), and every command above went through that same `PATH` pnpm with the pin removed. Worth a local `aspire start` before merge to close the loop.
